### PR TITLE
No vw-related logic in PickBestFeaturizer

### DIFF
--- a/src/learn_to_pick/__init__.py
+++ b/src/learn_to_pick/__init__.py
@@ -53,5 +53,4 @@ __all__ = [
     "VwPolicy",
     "VwLogger",
     "embed",
-    "stringify_embedding",
 ]

--- a/src/learn_to_pick/base.py
+++ b/src/learn_to_pick/base.py
@@ -13,7 +13,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    Callable
+    Callable,
 )
 
 from learn_to_pick.metrics import MetricsTrackerAverage, MetricsTrackerRollingWindow
@@ -183,9 +183,7 @@ class VwPolicy(Policy):
         import vowpal_wabbit_next as vw
 
         text_parser = vw.TextFormatParser(self.workspace)
-        return self.workspace.predict_one(
-            _parse_lines(text_parser, self.format(event))
-        )
+        return self.workspace.predict_one(_parse_lines(text_parser, self.format(event)))
 
     def learn(self, event: TEvent) -> None:
         import vowpal_wabbit_next as vw
@@ -489,18 +487,20 @@ class RLLoop(Generic[TEvent]):
 
 
 def _embed_string_type(
-    item: Union[str, _Embed], model: Any, namespace: str) -> Featurized:
+    item: Union[str, _Embed], model: Any, namespace: str
+) -> Featurized:
     """Helper function to embed a string or an _Embed object."""
     import re
+
     result = Featurized()
     if isinstance(item, _Embed):
         result[namespace] = DenseFeatures(model.encode(item.value))
         if item.keep:
             keep_str = item.value.replace(" ", "_")
-            result[namespace] = {'raw': re.sub(r"[\t\n\r\f\v]+", " ", keep_str)}
+            result[namespace] = {"raw": re.sub(r"[\t\n\r\f\v]+", " ", keep_str)}
     elif isinstance(item, str):
         encoded = item.replace(" ", "_")
-        result[namespace] = {'raw': re.sub(r"[\t\n\r\f\v]+", " ", encoded)}
+        result[namespace] = {"raw": re.sub(r"[\t\n\r\f\v]+", " ", encoded)}
     else:
         raise ValueError(f"Unsupported type {type(item)} for embedding")
 
@@ -513,7 +513,7 @@ def _embed_dict_type(item: Dict, model: Any) -> Featurized:
     for ns, embed_item in item.items():
         if isinstance(embed_item, list):
             for idx, embed_list_item in enumerate(embed_item):
-                result.merge(_embed_string_type(embed_list_item, model, f'{ns}_{idx}'))
+                result.merge(_embed_string_type(embed_list_item, model, f"{ns}_{idx}"))
         else:
             result.merge(_embed_string_type(embed_item, model, ns))
     return result
@@ -529,7 +529,7 @@ def _embed_list_type(
         elif isinstance(embed_item, list):
             result.append(Featurized())
             for idx, embed_list_item in enumerate(embed_item):
-                result[-1].merge(_embed_string_type(embed_list_item, model, f'{idx}'))
+                result[-1].merge(_embed_string_type(embed_list_item, model, f"{idx}"))
         else:
             result.append(_embed_string_type(embed_item, model, namespace))
     return result

--- a/src/learn_to_pick/base.py
+++ b/src/learn_to_pick/base.py
@@ -89,10 +89,6 @@ def EmbedAndKeep(anything: Any) -> Any:
 # helper functions
 
 
-def _stringify_embedding(embedding: List) -> str:
-    return " ".join([f"{i}:{e}" for i, e in enumerate(embedding)])
-
-
 def _parse_lines(parser: "vw.TextFormatParser", input_str: str) -> List["vw.Example"]:
     return [parser.parse_line(line) for line in input_str.split("\n")]
 
@@ -493,9 +489,9 @@ def _embed_string_type(
     import re
     result = Featurized()
     if isinstance(item, _Embed):
-        result[namespace] = model.encode(item.value)
+        result[namespace] = DenseFeatures(model.encode(item.value))
         if item.keep:
-            keep_str = item.value.replace(" ", "_") + " "
+            keep_str = item.value.replace(" ", "_")
             result[namespace] = {'raw': re.sub(r"[\t\n\r\f\v]+", " ", keep_str)}
     elif isinstance(item, str):
         encoded = item.replace(" ", "_")
@@ -512,7 +508,7 @@ def _embed_dict_type(item: Dict, model: Any) -> Featurized:
     for ns, embed_item in item.items():
         if isinstance(embed_item, list):
             for idx, embed_list_item in enumerate(embed_item):
-                result.merge(_embed_string_type(embed_list_item, model, f'{idx}_{ns}'))
+                result.merge(_embed_string_type(embed_list_item, model, f'{ns}_{idx}'))
         else:
             result.merge(_embed_string_type(embed_item, model, ns))
     return result

--- a/src/learn_to_pick/base.py
+++ b/src/learn_to_pick/base.py
@@ -165,10 +165,9 @@ class VwPolicy(Policy):
         featurizer: Featurizer,
         formatter: Callable,
         vw_logger: VwLogger,
-        *args: Any,
         **kwargs: Any,
     ):
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self.model_repo = model_repo
         self.vw_cmd = vw_cmd
         self.workspace = self.model_repo.load(vw_cmd)

--- a/src/learn_to_pick/base.py
+++ b/src/learn_to_pick/base.py
@@ -497,10 +497,10 @@ def _embed_string_type(
         result[namespace] = DenseFeatures(model.encode(item.value))
         if item.keep:
             keep_str = item.value.replace(" ", "_")
-            result[namespace] = {"raw": re.sub(r"[\t\n\r\f\v]+", " ", keep_str)}
+            result[namespace] = {"default_ft": re.sub(r"[\t\n\r\f\v]+", " ", keep_str)}
     elif isinstance(item, str):
         encoded = item.replace(" ", "_")
-        result[namespace] = {"raw": re.sub(r"[\t\n\r\f\v]+", " ", encoded)}
+        result[namespace] = {"default_ft": re.sub(r"[\t\n\r\f\v]+", " ", encoded)}
     else:
         raise ValueError(f"Unsupported type {type(item)} for embedding")
 

--- a/src/learn_to_pick/features.py
+++ b/src/learn_to_pick/features.py
@@ -1,0 +1,29 @@
+from typing import Union, Optional, Dict, List
+import numpy as np
+
+class SparseFeatures(dict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+
+class DenseFeatures(list):
+    def __init__(self, *args, **kwargs):
+        super().__init__(np.array(*args, **kwargs))
+
+
+class Featurized:
+    def __init__(self, sparse: Optional[Dict[str, SparseFeatures]] = None, dense: Optional[Dict[str, DenseFeatures]] = None):
+        self.sparse = sparse or {}
+        self.dense = dense or {}
+
+    def __setitem__(self, key, value):
+        if isinstance(value, Dict):
+            self.sparse[key] = SparseFeatures(value)
+        elif isinstance(value, List) or isinstance(value, np.ndarray):
+            self.dense[key] = DenseFeatures(value)
+        else:
+            raise ValueError(f'Cannot convert {type(value)} to either DenseFeatures or SparseFeatures')
+        
+    def merge(self, other):
+        self.sparse.update(other.sparse)
+        self.dense.update(other.dense)

--- a/src/learn_to_pick/features.py
+++ b/src/learn_to_pick/features.py
@@ -1,6 +1,7 @@
 from typing import Union, Optional, Dict, List
 import numpy as np
 
+
 class SparseFeatures(dict):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -12,7 +13,11 @@ class DenseFeatures(list):
 
 
 class Featurized:
-    def __init__(self, sparse: Optional[Dict[str, SparseFeatures]] = None, dense: Optional[Dict[str, DenseFeatures]] = None):
+    def __init__(
+        self,
+        sparse: Optional[Dict[str, SparseFeatures]] = None,
+        dense: Optional[Dict[str, DenseFeatures]] = None,
+    ):
         self.sparse = sparse or {}
         self.dense = dense or {}
 
@@ -22,8 +27,10 @@ class Featurized:
         elif isinstance(value, List) or isinstance(value, np.ndarray):
             self.dense[key] = DenseFeatures(value)
         else:
-            raise ValueError(f'Cannot convert {type(value)} to either DenseFeatures or SparseFeatures')
-        
+            raise ValueError(
+                f"Cannot convert {type(value)} to either DenseFeatures or SparseFeatures"
+            )
+
     def merge(self, other):
         self.sparse.update(other.sparse)
         self.dense.update(other.dense)

--- a/src/learn_to_pick/pick_best.py
+++ b/src/learn_to_pick/pick_best.py
@@ -123,14 +123,14 @@ class PickBestFeaturizer(base.Featurizer[PickBestEvent]):
     def _dotproducts(self, context, actions):
         _context_dense = base.Featurized()
         for ns in context.sparse.keys():
-            if "raw" in context.sparse[ns]:
-                _context_dense[ns] = self.model.encode(context.sparse[ns]["raw"])
+            if "default_ft" in context.sparse[ns]:
+                _context_dense[ns] = self.model.encode(context.sparse[ns]["default_ft"])
 
         _actions_dense = [base.Featurized() for _ in range(len(actions))]
         for _action, action in zip(_actions_dense, actions):
             for ns in action.sparse.keys():
-                if "raw" in action.sparse[ns]:
-                    _action[ns] = self.model.encode(action.sparse[ns]["raw"])
+                if "default_ft" in action.sparse[ns]:
+                    _action[ns] = self.model.encode(action.sparse[ns]["default_ft"])
 
         context_names = list(_context_dense.dense.keys())
         context_matrix = np.stack(list(_context_dense.dense.values()))
@@ -146,8 +146,8 @@ class PickBestFeaturizer(base.Featurizer[PickBestEvent]):
     def _generic_namespace(self, featurized):
         result = base.SparseFeatures()
         for ns in featurized.sparse.keys():
-            if "raw" in featurized.sparse[ns]:
-                result[ns] = featurized.sparse[ns]["raw"]
+            if "default_ft" in featurized.sparse[ns]:
+                result[ns] = featurized.sparse[ns]["default_ft"]
         return result
 
     def _generic_namespaces(self, context, actions):

--- a/src/learn_to_pick/pick_best.py
+++ b/src/learn_to_pick/pick_best.py
@@ -85,7 +85,7 @@ class PickBestFeaturizer(base.Featurizer[PickBestEvent]):
         self.model = model
         self.auto_embed = auto_embed
 
-    def get_context_and_action_embeddings(self, event: PickBestEvent) -> tuple:
+    def _get_context_and_action_embeddings(self, event: PickBestEvent) -> tuple:
         context_emb = base.embed(event.based_on, self.model) if event.based_on else None
         to_select_from_var_name, to_select_from = next(
             iter(event.to_select_from.items()), (None, None)
@@ -107,7 +107,7 @@ class PickBestFeaturizer(base.Featurizer[PickBestEvent]):
             )
         return context_emb, action_embs
 
-    def get_indexed_dot_product(self, context_emb: List, action_embs: List) -> Dict:
+    def _get_indexed_dot_product(self, context_emb: List, action_embs: List) -> Dict:
         import numpy as np
 
         unique_contexts = set()
@@ -147,9 +147,9 @@ class PickBestFeaturizer(base.Featurizer[PickBestEvent]):
 
         return indexed_dot_product
 
-    def format_auto_embed_on(self, event: PickBestEvent) -> str:
-        context_emb, action_embs = self.get_context_and_action_embeddings(event)
-        indexed_dot_product = self.get_indexed_dot_product(context_emb, action_embs)
+    def _format_auto_embed_on(self, event: PickBestEvent) -> str:
+        context_emb, action_embs = self._get_context_and_action_embeddings(event)
+        indexed_dot_product = self._get_indexed_dot_product(context_emb, action_embs)
 
         nactions = len(action_embs)
 
@@ -179,7 +179,7 @@ class PickBestFeaturizer(base.Featurizer[PickBestEvent]):
 
         return "\n".join([shared_str] + actions_str)
 
-    def format_auto_embed_off(self, event: PickBestEvent) -> str:
+    def _format_auto_embed_off(self, event: PickBestEvent) -> str:
         """
         Converts the `BasedOn` and `ToSelectFrom` into a format that can be used by VW
         """
@@ -197,9 +197,9 @@ class PickBestFeaturizer(base.Featurizer[PickBestEvent]):
 
     def format(self, event: PickBestEvent) -> str:
         if self.auto_embed:
-            return self.format_auto_embed_on(event)
+            return self._format_auto_embed_on(event)
         else:
-            return self.format_auto_embed_off(event)
+            return self._format_auto_embed_off(event)
 
 
 class PickBestRandomPolicy(base.Policy[PickBestEvent]):

--- a/tests/unit_tests/test_pick_best_call.py
+++ b/tests/unit_tests/test_pick_best_call.py
@@ -5,6 +5,7 @@ from test_utils import MockEncoder, MockEncoderReturnsList, assert_vw_ex_equals
 
 import learn_to_pick
 import learn_to_pick.base as rl_loop
+from learn_to_pick.pick_best import vw_cb_formatter
 
 encoded_keyword = "[encoded]"
 
@@ -179,7 +180,7 @@ def test_everything_embedded() -> None:
         action=rl_loop.EmbedAndKeep(learn_to_pick.ToSelectFrom(actions)),
     )
     picked_metadata = response["picked_metadata"]  # type: ignore
-    vw_str = featurizer.format(picked_metadata)  # type: ignore
+    vw_str = vw_cb_formatter(*featurizer.featurize(picked_metadata))  # type: ignore
     assert_vw_ex_equals(vw_str, expected)
 
 
@@ -205,7 +206,7 @@ def test_default_auto_embedder_is_off() -> None:
         action=learn_to_pick.base.ToSelectFrom(actions),
     )
     picked_metadata = response["picked_metadata"]  # type: ignore
-    vw_str = featurizer.format(picked_metadata)  # type: ignore
+    vw_str = vw_cb_formatter(*featurizer.featurize(picked_metadata))  # type: ignore
     assert_vw_ex_equals(vw_str, expected)
 
 
@@ -231,7 +232,7 @@ def test_default_w_embeddings_off() -> None:
         action=learn_to_pick.ToSelectFrom(actions),
     )
     picked_metadata = response["picked_metadata"]  # type: ignore
-    vw_str = featurizer.format(picked_metadata)  # type: ignore
+    vw_str = vw_cb_formatter(*featurizer.featurize(picked_metadata))  # type: ignore
     assert_vw_ex_equals(vw_str, expected)
 
 
@@ -258,7 +259,7 @@ def test_default_w_embeddings_on() -> None:
         action=learn_to_pick.ToSelectFrom(actions),
     )
     picked_metadata = response["picked_metadata"]  # type: ignore
-    vw_str = featurizer.format(picked_metadata)  # type: ignore
+    vw_str = vw_cb_formatter(*featurizer.featurize(picked_metadata))  # type: ignore
     assert_vw_ex_equals(vw_str, expected)
 
 

--- a/tests/unit_tests/test_pick_best_call.py
+++ b/tests/unit_tests/test_pick_best_call.py
@@ -163,15 +163,18 @@ def test_everything_embedded() -> None:
     str2 = "1"
     str3 = "2"
     action_dense = "0:1.0 1:0.0"
-    
+
     ctx_str_1 = "context1"
     encoded_ctx_str_1 = "0:8.0 1:0.0"
 
-    expected = "\n".join([
-        f"shared |User_dense {encoded_ctx_str_1} |User_sparse raw:={ctx_str_1}",
-        f"|action_dense {action_dense} |action_sparse raw:={str1}",
-        f"|action_dense {action_dense} |action_sparse raw:={str2}",
-        f"|action_dense {action_dense} |action_sparse raw:={str3}"])  # noqa
+    expected = "\n".join(
+        [
+            f"shared |User_dense {encoded_ctx_str_1} |User_sparse raw:={ctx_str_1}",
+            f"|action_dense {action_dense} |action_sparse raw:={str1}",
+            f"|action_dense {action_dense} |action_sparse raw:={str2}",
+            f"|action_dense {action_dense} |action_sparse raw:={str3}",
+        ]
+    )  # noqa
 
     actions = [str1, str2, str3]
 
@@ -193,11 +196,14 @@ def test_default_auto_embedder_is_off() -> None:
     str3 = "2"
     ctx_str_1 = "context1"
 
-    expected = "\n".join([
-        f"shared |User_sparse raw:={ctx_str_1}",
-        f"|action_sparse raw:={str1}",
-        f"|action_sparse raw:={str2}",
-        f"|action_sparse raw:={str3}"])  # noqa
+    expected = "\n".join(
+        [
+            f"shared |User_sparse raw:={ctx_str_1}",
+            f"|action_sparse raw:={str1}",
+            f"|action_sparse raw:={str2}",
+            f"|action_sparse raw:={str3}",
+        ]
+    )  # noqa
 
     actions = [str1, str2, str3]
 
@@ -219,11 +225,14 @@ def test_default_w_embeddings_off() -> None:
     str3 = "2"
     ctx_str_1 = "context1"
 
-    expected = "\n".join([
-        f"shared |User_sparse raw:={ctx_str_1}",
-        f"|action_sparse raw:={str1}",
-        f"|action_sparse raw:={str2}",
-        f"|action_sparse raw:={str3}"])  # noqa
+    expected = "\n".join(
+        [
+            f"shared |User_sparse raw:={ctx_str_1}",
+            f"|action_sparse raw:={str1}",
+            f"|action_sparse raw:={str2}",
+            f"|action_sparse raw:={str3}",
+        ]
+    )  # noqa
 
     actions = [str1, str2, str3]
 
@@ -247,10 +256,13 @@ def test_default_w_embeddings_on() -> None:
     ctx_str_1 = "context1"
     dot_prod = "dotprod_sparse User_action:5.0"  # dot prod of [1.0, 2.0] and [1.0, 2.0]
 
-    expected = "\n".join([
-        f"shared |User_sparse raw:={ctx_str_1} |@_sparse User:={ctx_str_1}",
-        f"|action_sparse raw:={str1} |{dot_prod} |#_sparse action:={str1} ",
-        f"|action_sparse raw:={str2} |{dot_prod} |#_sparse action:={str2} "])  # noqa
+    expected = "\n".join(
+        [
+            f"shared |User_sparse raw:={ctx_str_1} |@_sparse User:={ctx_str_1}",
+            f"|action_sparse raw:={str1} |{dot_prod} |#_sparse action:={str1} ",
+            f"|action_sparse raw:={str2} |{dot_prod} |#_sparse action:={str2} ",
+        ]
+    )  # noqa
 
     actions = [str1, str2]
 

--- a/tests/unit_tests/test_pick_best_call.py
+++ b/tests/unit_tests/test_pick_best_call.py
@@ -161,15 +161,16 @@ def test_everything_embedded() -> None:
     str1 = "0"
     str2 = "1"
     str3 = "2"
-    encoded_str1 = rl_loop._stringify_embedding(list(encoded_keyword + str1))
-    encoded_str2 = rl_loop._stringify_embedding(list(encoded_keyword + str2))
-    encoded_str3 = rl_loop._stringify_embedding(list(encoded_keyword + str3))
-
+    action_dense = "0:1.0 1:0.0"
+    
     ctx_str_1 = "context1"
+    encoded_ctx_str_1 = "0:8.0 1:0.0"
 
-    encoded_ctx_str_1 = rl_loop._stringify_embedding(list(encoded_keyword + ctx_str_1))
-
-    expected = f"""shared |User {ctx_str_1 + " " + encoded_ctx_str_1} \n|action {str1 + " " + encoded_str1} \n|action {str2 + " " + encoded_str2} \n|action {str3 + " " + encoded_str3} """  # noqa
+    expected = "\n".join([
+        f"shared |User_dense {encoded_ctx_str_1} |User_sparse raw:={ctx_str_1}",
+        f"|action_dense {action_dense} |action_sparse raw:={str1}",
+        f"|action_dense {action_dense} |action_sparse raw:={str2}",
+        f"|action_dense {action_dense} |action_sparse raw:={str3}"])  # noqa
 
     actions = [str1, str2, str3]
 
@@ -191,7 +192,11 @@ def test_default_auto_embedder_is_off() -> None:
     str3 = "2"
     ctx_str_1 = "context1"
 
-    expected = f"""shared |User {ctx_str_1} \n|action {str1} \n|action {str2} \n|action {str3} """  # noqa
+    expected = "\n".join([
+        f"shared |User_sparse raw:={ctx_str_1}",
+        f"|action_sparse raw:={str1}",
+        f"|action_sparse raw:={str2}",
+        f"|action_sparse raw:={str3}"])  # noqa
 
     actions = [str1, str2, str3]
 
@@ -213,7 +218,11 @@ def test_default_w_embeddings_off() -> None:
     str3 = "2"
     ctx_str_1 = "context1"
 
-    expected = f"""shared |User {ctx_str_1} \n|action {str1} \n|action {str2} \n|action {str3} """  # noqa
+    expected = "\n".join([
+        f"shared |User_sparse raw:={ctx_str_1}",
+        f"|action_sparse raw:={str1}",
+        f"|action_sparse raw:={str2}",
+        f"|action_sparse raw:={str3}"])  # noqa
 
     actions = [str1, str2, str3]
 
@@ -235,9 +244,12 @@ def test_default_w_embeddings_on() -> None:
     str1 = "0"
     str2 = "1"
     ctx_str_1 = "context1"
-    dot_prod = "dotprod 0:5.0"  # dot prod of [1.0, 2.0] and [1.0, 2.0]
+    dot_prod = "dotprod_sparse User_action:5.0"  # dot prod of [1.0, 2.0] and [1.0, 2.0]
 
-    expected = f"""shared |User {ctx_str_1} |@ User={ctx_str_1}\n|action {str1} |# action={str1} |{dot_prod}\n|action {str2} |# action={str2} |{dot_prod}"""  # noqa
+    expected = "\n".join([
+        f"shared |User_sparse raw:={ctx_str_1} |@_sparse User:={ctx_str_1}",
+        f"|action_sparse raw:={str1} |{dot_prod} |#_sparse action:={str1} ",
+        f"|action_sparse raw:={str2} |{dot_prod} |#_sparse action:={str2} "])  # noqa
 
     actions = [str1, str2]
 

--- a/tests/unit_tests/test_pick_best_call.py
+++ b/tests/unit_tests/test_pick_best_call.py
@@ -169,10 +169,10 @@ def test_everything_embedded() -> None:
 
     expected = "\n".join(
         [
-            f"shared |User_dense {encoded_ctx_str_1} |User_sparse raw:={ctx_str_1}",
-            f"|action_dense {action_dense} |action_sparse raw:={str1}",
-            f"|action_dense {action_dense} |action_sparse raw:={str2}",
-            f"|action_dense {action_dense} |action_sparse raw:={str3}",
+            f"shared |User_dense {encoded_ctx_str_1} |User_sparse default_ft:={ctx_str_1}",
+            f"|action_dense {action_dense} |action_sparse default_ft:={str1}",
+            f"|action_dense {action_dense} |action_sparse default_ft:={str2}",
+            f"|action_dense {action_dense} |action_sparse default_ft:={str3}",
         ]
     )  # noqa
 
@@ -198,10 +198,10 @@ def test_default_auto_embedder_is_off() -> None:
 
     expected = "\n".join(
         [
-            f"shared |User_sparse raw:={ctx_str_1}",
-            f"|action_sparse raw:={str1}",
-            f"|action_sparse raw:={str2}",
-            f"|action_sparse raw:={str3}",
+            f"shared |User_sparse default_ft:={ctx_str_1}",
+            f"|action_sparse default_ft:={str1}",
+            f"|action_sparse default_ft:={str2}",
+            f"|action_sparse default_ft:={str3}",
         ]
     )  # noqa
 
@@ -227,10 +227,10 @@ def test_default_w_embeddings_off() -> None:
 
     expected = "\n".join(
         [
-            f"shared |User_sparse raw:={ctx_str_1}",
-            f"|action_sparse raw:={str1}",
-            f"|action_sparse raw:={str2}",
-            f"|action_sparse raw:={str3}",
+            f"shared |User_sparse default_ft:={ctx_str_1}",
+            f"|action_sparse default_ft:={str1}",
+            f"|action_sparse default_ft:={str2}",
+            f"|action_sparse default_ft:={str3}",
         ]
     )  # noqa
 
@@ -258,9 +258,9 @@ def test_default_w_embeddings_on() -> None:
 
     expected = "\n".join(
         [
-            f"shared |User_sparse raw:={ctx_str_1} |@_sparse User:={ctx_str_1}",
-            f"|action_sparse raw:={str1} |{dot_prod} |#_sparse action:={str1} ",
-            f"|action_sparse raw:={str2} |{dot_prod} |#_sparse action:={str2} ",
+            f"shared |User_sparse default_ft:={ctx_str_1} |@_sparse User:={ctx_str_1}",
+            f"|action_sparse default_ft:={str1} |{dot_prod} |#_sparse action:={str1} ",
+            f"|action_sparse default_ft:={str2} |{dot_prod} |#_sparse action:={str2} ",
         ]
     )  # noqa
 

--- a/tests/unit_tests/test_pick_best_text_embedder.py
+++ b/tests/unit_tests/test_pick_best_text_embedder.py
@@ -33,12 +33,15 @@ def test_pickbest_textembedder_no_label_no_emb() -> None:
         auto_embed=False, model=MockEncoder()
     )
     named_actions = {"action": ["0", "1", "2"]}
-    expected = "\n".join([
-        "shared |context_sparse raw:=context",
-        "|action_sparse raw:=0",
-        "|action_sparse raw:=1",
-        "|action_sparse raw:=2"])
-    
+    expected = "\n".join(
+        [
+            "shared |context_sparse raw:=context",
+            "|action_sparse raw:=0",
+            "|action_sparse raw:=1",
+            "|action_sparse raw:=2",
+        ]
+    )
+
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on={"context": "context"}
     )
@@ -51,11 +54,14 @@ def test_pickbest_textembedder_w_label_no_score_no_emb() -> None:
         auto_embed=False, model=MockEncoder()
     )
     named_actions = {"action": ["0", "1", "2"]}
-    expected = "\n".join([
-        "shared |context_sparse raw:=context",
-        "|action_sparse raw:=0",
-        "|action_sparse raw:=1",
-        "|action_sparse raw:=2"])
+    expected = "\n".join(
+        [
+            "shared |context_sparse raw:=context",
+            "|action_sparse raw:=0",
+            "|action_sparse raw:=1",
+            "|action_sparse raw:=2",
+        ]
+    )
     selected = pick_best_chain.PickBestSelected(index=0, probability=1.0)
     event = pick_best_chain.PickBestEvent(
         inputs={},
@@ -72,11 +78,14 @@ def test_pickbest_textembedder_w_full_label_no_emb() -> None:
         auto_embed=False, model=MockEncoder()
     )
     named_actions = {"action": ["0", "1", "2"]}
-    expected = "\n".join([
-        "shared |context_sparse raw:=context",
-        "0:-0.0:1.0 |action_sparse raw:=0",
-        "|action_sparse raw:=1",
-        "|action_sparse raw:=2"])
+    expected = "\n".join(
+        [
+            "shared |context_sparse raw:=context",
+            "0:-0.0:1.0 |action_sparse raw:=0",
+            "|action_sparse raw:=1",
+            "|action_sparse raw:=2",
+        ]
+    )
 
     selected = pick_best_chain.PickBestSelected(index=0, probability=1.0, score=0.0)
     event = pick_best_chain.PickBestEvent(
@@ -102,11 +111,14 @@ def test_pickbest_textembedder_w_full_label_w_emb() -> None:
 
     named_actions = {"action": rl_chain.Embed([str1, str2, str3])}
     context = {"context": rl_chain.Embed(ctx_str)}
-    expected = "\n".join([
-        f"shared |context_dense {encoded_ctx_str}",
-        "0:-0.0:1.0 |action_dense 0:1.0 1:0.0",
-        "|action_dense 0:1.0 1:0.0",
-        "|action_dense 0:1.0 1:0.0"])  # noqa: E501
+    expected = "\n".join(
+        [
+            f"shared |context_dense {encoded_ctx_str}",
+            "0:-0.0:1.0 |action_dense 0:1.0 1:0.0",
+            "|action_dense 0:1.0 1:0.0",
+            "|action_dense 0:1.0 1:0.0",
+        ]
+    )  # noqa: E501
     selected = pick_best_chain.PickBestSelected(index=0, probability=1.0, score=0.0)
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context, selected=selected
@@ -128,11 +140,14 @@ def test_pickbest_textembedder_w_full_label_w_embed_and_keep() -> None:
 
     named_actions = {"action": rl_chain.EmbedAndKeep([str1, str2, str3])}
     context = {"context": rl_chain.EmbedAndKeep(ctx_str)}
-    expected = "\n".join([
-        f"shared |context_dense {encoded_ctx_str} |context_sparse raw:={ctx_str}",
-        "0:-0.0:1.0 |action_dense 0:1.0 1:0.0 |action_sparse raw:=0",
-        "|action_dense 0:1.0 1:0.0 |action_sparse raw:=1",
-        "|action_dense 0:1.0 1:0.0 |action_sparse raw:=2"])  # noqa: E501
+    expected = "\n".join(
+        [
+            f"shared |context_dense {encoded_ctx_str} |context_sparse raw:={ctx_str}",
+            "0:-0.0:1.0 |action_dense 0:1.0 1:0.0 |action_sparse raw:=0",
+            "|action_dense 0:1.0 1:0.0 |action_sparse raw:=1",
+            "|action_dense 0:1.0 1:0.0 |action_sparse raw:=2",
+        ]
+    )  # noqa: E501
     selected = pick_best_chain.PickBestSelected(index=0, probability=1.0, score=0.0)
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context, selected=selected
@@ -147,11 +162,14 @@ def test_pickbest_textembedder_more_namespaces_no_label_no_emb() -> None:
     )
     named_actions = {"action1": [{"a": "0", "b": "0"}, "1", "2"]}
     context = {"context1": "context1", "context2": "context2"}
-    expected = "\n".join([
-        "shared |context1_sparse raw:=context1 |context2_sparse raw:=context2 ",
-        "|a_sparse raw:=0 |b_sparse raw:=0",
-        "|action1_sparse raw:=1",
-        "|action1_sparse raw:=2"])  # noqa: E501
+    expected = "\n".join(
+        [
+            "shared |context1_sparse raw:=context1 |context2_sparse raw:=context2 ",
+            "|a_sparse raw:=0 |b_sparse raw:=0",
+            "|action1_sparse raw:=1",
+            "|action1_sparse raw:=2",
+        ]
+    )  # noqa: E501
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context
     )
@@ -165,11 +183,14 @@ def test_pickbest_textembedder_more_namespaces_w_label_no_emb() -> None:
     )
     named_actions = {"action": [{"a": "0", "b": "0"}, "1", "2"]}
     context = {"context1": "context1", "context2": "context2"}
-    expected = "\n".join([
-        "shared |context1_sparse raw:=context1 |context2_sparse raw:=context2",
-        "|a_sparse raw:=0 |b_sparse raw:=0",
-        "|action_sparse raw:=1",
-        "|action_sparse raw:=2"])  # noqa: E501
+    expected = "\n".join(
+        [
+            "shared |context1_sparse raw:=context1 |context2_sparse raw:=context2",
+            "|a_sparse raw:=0 |b_sparse raw:=0",
+            "|action_sparse raw:=1",
+            "|action_sparse raw:=2",
+        ]
+    )  # noqa: E501
     selected = pick_best_chain.PickBestSelected(index=0, probability=1.0)
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context, selected=selected
@@ -184,11 +205,14 @@ def test_pickbest_textembedder_more_namespaces_w_full_label_no_emb() -> None:
     )
     named_actions = {"action": [{"a": "0", "b": "0"}, "1", "2"]}
     context = {"context1": "context1", "context2": "context2"}
-    expected = "\n".join([
-        "shared |context1_sparse raw:=context1 |context2_sparse raw:=context2",
-        "0:-0.0:1.0 |a_sparse raw:=0 |b_sparse raw:=0",
-        "|action_sparse raw:=1",
-        "|action_sparse raw:=2"])  # noqa: E501
+    expected = "\n".join(
+        [
+            "shared |context1_sparse raw:=context1 |context2_sparse raw:=context2",
+            "0:-0.0:1.0 |a_sparse raw:=0 |b_sparse raw:=0",
+            "|action_sparse raw:=1",
+            "|action_sparse raw:=2",
+        ]
+    )  # noqa: E501
     selected = pick_best_chain.PickBestSelected(index=0, probability=1.0, score=0.0)
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context, selected=selected
@@ -216,11 +240,14 @@ def test_pickbest_textembedder_more_namespaces_w_full_label_w_full_emb() -> None
         "context1": rl_chain.Embed(ctx_str_1),
         "context2": rl_chain.Embed(ctx_str_2),
     }
-    expected = "\n".join([
-        f"shared |context1_dense {encoded_ctx_str_1} |context2_dense {encoded_ctx_str_2}",
-        f"0:-0.0:1.0 |a_dense 0:1.0 1:0.0 |b_dense 0:1.0 1:0.0",
-        f"|action_dense 0:1.0 1:0.0",
-        f"|action_dense 0:1.0 1:0.0"])  # noqa: E501
+    expected = "\n".join(
+        [
+            f"shared |context1_dense {encoded_ctx_str_1} |context2_dense {encoded_ctx_str_2}",
+            f"0:-0.0:1.0 |a_dense 0:1.0 1:0.0 |b_dense 0:1.0 1:0.0",
+            f"|action_dense 0:1.0 1:0.0",
+            f"|action_dense 0:1.0 1:0.0",
+        ]
+    )  # noqa: E501
 
     selected = pick_best_chain.PickBestSelected(index=0, probability=1.0, score=0.0)
     event = pick_best_chain.PickBestEvent(
@@ -253,12 +280,15 @@ def test_pickbest_textembedder_more_namespaces_w_full_label_w_full_embed_and_kee
         "context1": rl_chain.EmbedAndKeep(ctx_str_1),
         "context2": rl_chain.EmbedAndKeep(ctx_str_2),
     }
-    expected = "\n".join([
-        f"shared |context1_dense {encoded_ctx_str_1} |context2_dense {encoded_ctx_str_2} |context1_sparse raw:={ctx_str_1} |context2_sparse raw:={ctx_str_2}",
-        f"0:-0.0:1.0 |a_dense 0:1.0 1:0.0 |b_dense 0:1.0 1:0.0 |a_sparse raw:=0 |b_sparse raw:=0",
-        f"|action_dense 0:1.0 1:0.0 |action_sparse raw:=1",
-        f"|action_dense 0:1.0 1:0.0 |action_sparse raw:=2"])  # noqa: E501
-    
+    expected = "\n".join(
+        [
+            f"shared |context1_dense {encoded_ctx_str_1} |context2_dense {encoded_ctx_str_2} |context1_sparse raw:={ctx_str_1} |context2_sparse raw:={ctx_str_2}",
+            f"0:-0.0:1.0 |a_dense 0:1.0 1:0.0 |b_dense 0:1.0 1:0.0 |a_sparse raw:=0 |b_sparse raw:=0",
+            f"|action_dense 0:1.0 1:0.0 |action_sparse raw:=1",
+            f"|action_dense 0:1.0 1:0.0 |action_sparse raw:=2",
+        ]
+    )  # noqa: E501
+
     selected = pick_best_chain.PickBestSelected(index=0, probability=1.0, score=0.0)
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context, selected=selected
@@ -285,11 +315,14 @@ def test_pickbest_textembedder_more_namespaces_w_full_label_w_partial_emb() -> N
     }
     context = {"context1": ctx_str_1, "context2": rl_chain.Embed(ctx_str_2)}
 
-    expected = "\n".join([
-        f"shared |context2_dense {encoded_ctx_str_2} |context1_sparse raw:={ctx_str_1}",
-        f"0:-0.0:1.0 |b_dense 0:1.0 1:0.0 |a_sparse raw:=0",
-        f"|action_sparse raw:=1",
-        f"|action_dense 0:1.0 1:0.0"])  # noqa: E501
+    expected = "\n".join(
+        [
+            f"shared |context2_dense {encoded_ctx_str_2} |context1_sparse raw:={ctx_str_1}",
+            f"0:-0.0:1.0 |b_dense 0:1.0 1:0.0 |a_sparse raw:=0",
+            f"|action_sparse raw:=1",
+            f"|action_dense 0:1.0 1:0.0",
+        ]
+    )  # noqa: E501
 
     selected = pick_best_chain.PickBestSelected(index=0, probability=1.0, score=0.0)
     event = pick_best_chain.PickBestEvent(
@@ -320,11 +353,14 @@ def test_pickbest_textembedder_more_namespaces_w_full_label_w_partial_emakeep() 
         ]
     }
     context = {"context1": ctx_str_1, "context2": rl_chain.EmbedAndKeep(ctx_str_2)}
-    expected = "\n".join([
-        f"shared |context2_dense {encoded_ctx_str_2} |context1_sparse raw:={ctx_str_1} |context2_sparse raw:={ctx_str_2}",
-        f"0:-0.0:1.0 |b_dense 0:1.0 1:0.0 |a_sparse raw:=0 |b_sparse raw:=0",
-        f"|action_sparse raw:=1",
-        f"|action_dense 0:1.0 1:0.0 |action_sparse raw:=2"])  # noqa: E501
+    expected = "\n".join(
+        [
+            f"shared |context2_dense {encoded_ctx_str_2} |context1_sparse raw:={ctx_str_1} |context2_sparse raw:={ctx_str_2}",
+            f"0:-0.0:1.0 |b_dense 0:1.0 1:0.0 |a_sparse raw:=0 |b_sparse raw:=0",
+            f"|action_sparse raw:=1",
+            f"|action_dense 0:1.0 1:0.0 |action_sparse raw:=2",
+        ]
+    )  # noqa: E501
     selected = pick_best_chain.PickBestSelected(index=0, probability=1.0, score=0.0)
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context, selected=selected
@@ -348,10 +384,13 @@ def test_raw_features_underscored() -> None:
     # No embeddings
     named_actions = {"action": [str1]}
     context = {"context": ctx_str}
-    expected_no_embed = "\n".join([
-        f"shared |context_sparse raw:={ctx_str_underscored}",
-        f"|action_sparse raw:={str1_underscored}"])
-    
+    expected_no_embed = "\n".join(
+        [
+            f"shared |context_sparse raw:={ctx_str_underscored}",
+            f"|action_sparse raw:={str1_underscored}",
+        ]
+    )
+
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context
     )
@@ -361,9 +400,9 @@ def test_raw_features_underscored() -> None:
     # Just embeddings
     named_actions = {"action": rl_chain.Embed([str1])}
     context = {"context": rl_chain.Embed(ctx_str)}
-    expected_embed = "\n".join([
-        f"shared |context_dense {encoded_ctx_str}",
-        f"|action_dense {encoded_str1}"])
+    expected_embed = "\n".join(
+        [f"shared |context_dense {encoded_ctx_str}", f"|action_dense {encoded_str1}"]
+    )
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context
     )
@@ -373,9 +412,12 @@ def test_raw_features_underscored() -> None:
     # Embeddings and raw features
     named_actions = {"action": rl_chain.EmbedAndKeep([str1])}
     context = {"context": rl_chain.EmbedAndKeep(ctx_str)}
-    expected_embed_and_keep = "\n".join([
-        f"shared |context_dense {encoded_ctx_str} |context_sparse raw:={ctx_str_underscored}",
-        f"|action_dense {encoded_str1} |action_sparse raw:={str1_underscored}"])  # noqa: E501
+    expected_embed_and_keep = "\n".join(
+        [
+            f"shared |context_dense {encoded_ctx_str} |context_sparse raw:={ctx_str_underscored}",
+            f"|action_dense {encoded_str1} |action_sparse raw:={str1_underscored}",
+        ]
+    )  # noqa: E501
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context
     )

--- a/tests/unit_tests/test_pick_best_text_embedder.py
+++ b/tests/unit_tests/test_pick_best_text_embedder.py
@@ -35,10 +35,10 @@ def test_pickbest_textembedder_no_label_no_emb() -> None:
     named_actions = {"action": ["0", "1", "2"]}
     expected = "\n".join(
         [
-            "shared |context_sparse raw:=context",
-            "|action_sparse raw:=0",
-            "|action_sparse raw:=1",
-            "|action_sparse raw:=2",
+            "shared |context_sparse default_ft:=context",
+            "|action_sparse default_ft:=0",
+            "|action_sparse default_ft:=1",
+            "|action_sparse default_ft:=2",
         ]
     )
 
@@ -56,10 +56,10 @@ def test_pickbest_textembedder_w_label_no_score_no_emb() -> None:
     named_actions = {"action": ["0", "1", "2"]}
     expected = "\n".join(
         [
-            "shared |context_sparse raw:=context",
-            "|action_sparse raw:=0",
-            "|action_sparse raw:=1",
-            "|action_sparse raw:=2",
+            "shared |context_sparse default_ft:=context",
+            "|action_sparse default_ft:=0",
+            "|action_sparse default_ft:=1",
+            "|action_sparse default_ft:=2",
         ]
     )
     selected = pick_best_chain.PickBestSelected(index=0, probability=1.0)
@@ -80,10 +80,10 @@ def test_pickbest_textembedder_w_full_label_no_emb() -> None:
     named_actions = {"action": ["0", "1", "2"]}
     expected = "\n".join(
         [
-            "shared |context_sparse raw:=context",
-            "0:-0.0:1.0 |action_sparse raw:=0",
-            "|action_sparse raw:=1",
-            "|action_sparse raw:=2",
+            "shared |context_sparse default_ft:=context",
+            "0:-0.0:1.0 |action_sparse default_ft:=0",
+            "|action_sparse default_ft:=1",
+            "|action_sparse default_ft:=2",
         ]
     )
 
@@ -142,10 +142,10 @@ def test_pickbest_textembedder_w_full_label_w_embed_and_keep() -> None:
     context = {"context": rl_chain.EmbedAndKeep(ctx_str)}
     expected = "\n".join(
         [
-            f"shared |context_dense {encoded_ctx_str} |context_sparse raw:={ctx_str}",
-            "0:-0.0:1.0 |action_dense 0:1.0 1:0.0 |action_sparse raw:=0",
-            "|action_dense 0:1.0 1:0.0 |action_sparse raw:=1",
-            "|action_dense 0:1.0 1:0.0 |action_sparse raw:=2",
+            f"shared |context_dense {encoded_ctx_str} |context_sparse default_ft:={ctx_str}",
+            "0:-0.0:1.0 |action_dense 0:1.0 1:0.0 |action_sparse default_ft:=0",
+            "|action_dense 0:1.0 1:0.0 |action_sparse default_ft:=1",
+            "|action_dense 0:1.0 1:0.0 |action_sparse default_ft:=2",
         ]
     )  # noqa: E501
     selected = pick_best_chain.PickBestSelected(index=0, probability=1.0, score=0.0)
@@ -164,10 +164,10 @@ def test_pickbest_textembedder_more_namespaces_no_label_no_emb() -> None:
     context = {"context1": "context1", "context2": "context2"}
     expected = "\n".join(
         [
-            "shared |context1_sparse raw:=context1 |context2_sparse raw:=context2 ",
-            "|a_sparse raw:=0 |b_sparse raw:=0",
-            "|action1_sparse raw:=1",
-            "|action1_sparse raw:=2",
+            "shared |context1_sparse default_ft:=context1 |context2_sparse default_ft:=context2 ",
+            "|a_sparse default_ft:=0 |b_sparse default_ft:=0",
+            "|action1_sparse default_ft:=1",
+            "|action1_sparse default_ft:=2",
         ]
     )  # noqa: E501
     event = pick_best_chain.PickBestEvent(
@@ -185,10 +185,10 @@ def test_pickbest_textembedder_more_namespaces_w_label_no_emb() -> None:
     context = {"context1": "context1", "context2": "context2"}
     expected = "\n".join(
         [
-            "shared |context1_sparse raw:=context1 |context2_sparse raw:=context2",
-            "|a_sparse raw:=0 |b_sparse raw:=0",
-            "|action_sparse raw:=1",
-            "|action_sparse raw:=2",
+            "shared |context1_sparse default_ft:=context1 |context2_sparse default_ft:=context2",
+            "|a_sparse default_ft:=0 |b_sparse default_ft:=0",
+            "|action_sparse default_ft:=1",
+            "|action_sparse default_ft:=2",
         ]
     )  # noqa: E501
     selected = pick_best_chain.PickBestSelected(index=0, probability=1.0)
@@ -207,10 +207,10 @@ def test_pickbest_textembedder_more_namespaces_w_full_label_no_emb() -> None:
     context = {"context1": "context1", "context2": "context2"}
     expected = "\n".join(
         [
-            "shared |context1_sparse raw:=context1 |context2_sparse raw:=context2",
-            "0:-0.0:1.0 |a_sparse raw:=0 |b_sparse raw:=0",
-            "|action_sparse raw:=1",
-            "|action_sparse raw:=2",
+            "shared |context1_sparse default_ft:=context1 |context2_sparse default_ft:=context2",
+            "0:-0.0:1.0 |a_sparse default_ft:=0 |b_sparse default_ft:=0",
+            "|action_sparse default_ft:=1",
+            "|action_sparse default_ft:=2",
         ]
     )  # noqa: E501
     selected = pick_best_chain.PickBestSelected(index=0, probability=1.0, score=0.0)
@@ -282,10 +282,10 @@ def test_pickbest_textembedder_more_namespaces_w_full_label_w_full_embed_and_kee
     }
     expected = "\n".join(
         [
-            f"shared |context1_dense {encoded_ctx_str_1} |context2_dense {encoded_ctx_str_2} |context1_sparse raw:={ctx_str_1} |context2_sparse raw:={ctx_str_2}",
-            f"0:-0.0:1.0 |a_dense 0:1.0 1:0.0 |b_dense 0:1.0 1:0.0 |a_sparse raw:=0 |b_sparse raw:=0",
-            f"|action_dense 0:1.0 1:0.0 |action_sparse raw:=1",
-            f"|action_dense 0:1.0 1:0.0 |action_sparse raw:=2",
+            f"shared |context1_dense {encoded_ctx_str_1} |context2_dense {encoded_ctx_str_2} |context1_sparse default_ft:={ctx_str_1} |context2_sparse default_ft:={ctx_str_2}",
+            f"0:-0.0:1.0 |a_dense 0:1.0 1:0.0 |b_dense 0:1.0 1:0.0 |a_sparse default_ft:=0 |b_sparse default_ft:=0",
+            f"|action_dense 0:1.0 1:0.0 |action_sparse default_ft:=1",
+            f"|action_dense 0:1.0 1:0.0 |action_sparse default_ft:=2",
         ]
     )  # noqa: E501
 
@@ -317,9 +317,9 @@ def test_pickbest_textembedder_more_namespaces_w_full_label_w_partial_emb() -> N
 
     expected = "\n".join(
         [
-            f"shared |context2_dense {encoded_ctx_str_2} |context1_sparse raw:={ctx_str_1}",
-            f"0:-0.0:1.0 |b_dense 0:1.0 1:0.0 |a_sparse raw:=0",
-            f"|action_sparse raw:=1",
+            f"shared |context2_dense {encoded_ctx_str_2} |context1_sparse default_ft:={ctx_str_1}",
+            f"0:-0.0:1.0 |b_dense 0:1.0 1:0.0 |a_sparse default_ft:=0",
+            f"|action_sparse default_ft:=1",
             f"|action_dense 0:1.0 1:0.0",
         ]
     )  # noqa: E501
@@ -355,10 +355,10 @@ def test_pickbest_textembedder_more_namespaces_w_full_label_w_partial_emakeep() 
     context = {"context1": ctx_str_1, "context2": rl_chain.EmbedAndKeep(ctx_str_2)}
     expected = "\n".join(
         [
-            f"shared |context2_dense {encoded_ctx_str_2} |context1_sparse raw:={ctx_str_1} |context2_sparse raw:={ctx_str_2}",
-            f"0:-0.0:1.0 |b_dense 0:1.0 1:0.0 |a_sparse raw:=0 |b_sparse raw:=0",
-            f"|action_sparse raw:=1",
-            f"|action_dense 0:1.0 1:0.0 |action_sparse raw:=2",
+            f"shared |context2_dense {encoded_ctx_str_2} |context1_sparse default_ft:={ctx_str_1} |context2_sparse default_ft:={ctx_str_2}",
+            f"0:-0.0:1.0 |b_dense 0:1.0 1:0.0 |a_sparse default_ft:=0 |b_sparse default_ft:=0",
+            f"|action_sparse default_ft:=1",
+            f"|action_dense 0:1.0 1:0.0 |action_sparse default_ft:=2",
         ]
     )  # noqa: E501
     selected = pick_best_chain.PickBestSelected(index=0, probability=1.0, score=0.0)
@@ -386,8 +386,8 @@ def test_raw_features_underscored() -> None:
     context = {"context": ctx_str}
     expected_no_embed = "\n".join(
         [
-            f"shared |context_sparse raw:={ctx_str_underscored}",
-            f"|action_sparse raw:={str1_underscored}",
+            f"shared |context_sparse default_ft:={ctx_str_underscored}",
+            f"|action_sparse default_ft:={str1_underscored}",
         ]
     )
 
@@ -414,8 +414,8 @@ def test_raw_features_underscored() -> None:
     context = {"context": rl_chain.EmbedAndKeep(ctx_str)}
     expected_embed_and_keep = "\n".join(
         [
-            f"shared |context_dense {encoded_ctx_str} |context_sparse raw:={ctx_str_underscored}",
-            f"|action_dense {encoded_str1} |action_sparse raw:={str1_underscored}",
+            f"shared |context_dense {encoded_ctx_str} |context_sparse default_ft:={ctx_str_underscored}",
+            f"|action_dense {encoded_str1} |action_sparse default_ft:={str1_underscored}",
         ]
     )  # noqa: E501
     event = pick_best_chain.PickBestEvent(

--- a/tests/unit_tests/test_pick_best_text_embedder.py
+++ b/tests/unit_tests/test_pick_best_text_embedder.py
@@ -4,10 +4,8 @@ from test_utils import MockEncoder, assert_vw_ex_equals
 import learn_to_pick.base as rl_chain
 import learn_to_pick.pick_best as pick_best_chain
 
-encoded_keyword = "[encoded]"
 
-
-def test_pickbest_textembedder_missing_context_throws() -> None:
+def test_pickbest_textembedder_missing_context_not_throws() -> None:
     featurizer = pick_best_chain.PickBestFeaturizer(
         auto_embed=False, model=MockEncoder()
     )
@@ -15,8 +13,7 @@ def test_pickbest_textembedder_missing_context_throws() -> None:
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_action, based_on={}
     )
-    with pytest.raises(ValueError):
-        featurizer.format(event)
+    featurizer.format(event)
 
 
 def test_pickbest_textembedder_missing_actions_throws() -> None:
@@ -34,8 +31,13 @@ def test_pickbest_textembedder_no_label_no_emb() -> None:
     featurizer = pick_best_chain.PickBestFeaturizer(
         auto_embed=False, model=MockEncoder()
     )
-    named_actions = {"action1": ["0", "1", "2"]}
-    expected = """shared |context context \n|action1 0 \n|action1 1 \n|action1 2 """
+    named_actions = {"action": ["0", "1", "2"]}
+    expected = "\n".join([
+        "shared |context_sparse raw:=context",
+        "|action_sparse raw:=0",
+        "|action_sparse raw:=1",
+        "|action_sparse raw:=2"])
+    
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on={"context": "context"}
     )
@@ -47,8 +49,12 @@ def test_pickbest_textembedder_w_label_no_score_no_emb() -> None:
     featurizer = pick_best_chain.PickBestFeaturizer(
         auto_embed=False, model=MockEncoder()
     )
-    named_actions = {"action1": ["0", "1", "2"]}
-    expected = """shared |context context \n|action1 0 \n|action1 1 \n|action1 2 """
+    named_actions = {"action": ["0", "1", "2"]}
+    expected = "\n".join([
+        "shared |context_sparse raw:=context",
+        "|action_sparse raw:=0",
+        "|action_sparse raw:=1",
+        "|action_sparse raw:=2"])
     selected = pick_best_chain.PickBestSelected(index=0, probability=1.0)
     event = pick_best_chain.PickBestEvent(
         inputs={},
@@ -64,10 +70,13 @@ def test_pickbest_textembedder_w_full_label_no_emb() -> None:
     featurizer = pick_best_chain.PickBestFeaturizer(
         auto_embed=False, model=MockEncoder()
     )
-    named_actions = {"action1": ["0", "1", "2"]}
-    expected = (
-        """shared |context context \n0:-0.0:1.0 |action1 0 \n|action1 1 \n|action1 2 """
-    )
+    named_actions = {"action": ["0", "1", "2"]}
+    expected = "\n".join([
+        "shared |context_sparse raw:=context",
+        "0:-0.0:1.0 |action_sparse raw:=0",
+        "|action_sparse raw:=1",
+        "|action_sparse raw:=2"])
+
     selected = pick_best_chain.PickBestSelected(index=0, probability=1.0, score=0.0)
     event = pick_best_chain.PickBestEvent(
         inputs={},
@@ -86,16 +95,17 @@ def test_pickbest_textembedder_w_full_label_w_emb() -> None:
     str1 = "0"
     str2 = "1"
     str3 = "2"
-    encoded_str1 = rl_chain._stringify_embedding(list(encoded_keyword + str1))
-    encoded_str2 = rl_chain._stringify_embedding(list(encoded_keyword + str2))
-    encoded_str3 = rl_chain._stringify_embedding(list(encoded_keyword + str3))
 
-    ctx_str_1 = "context1"
-    encoded_ctx_str_1 = rl_chain._stringify_embedding(list(encoded_keyword + ctx_str_1))
+    ctx_str = "ctx"
+    encoded_ctx_str = "0:3.0 1:0.0"
 
-    named_actions = {"action1": rl_chain.Embed([str1, str2, str3])}
-    context = {"context": rl_chain.Embed(ctx_str_1)}
-    expected = f"""shared |context {encoded_ctx_str_1} \n0:-0.0:1.0 |action1 {encoded_str1} \n|action1 {encoded_str2} \n|action1 {encoded_str3} """  # noqa: E501
+    named_actions = {"action": rl_chain.Embed([str1, str2, str3])}
+    context = {"context": rl_chain.Embed(ctx_str)}
+    expected = "\n".join([
+        f"shared |context_dense {encoded_ctx_str}",
+        "0:-0.0:1.0 |action_dense 0:1.0 1:0.0",
+        "|action_dense 0:1.0 1:0.0",
+        "|action_dense 0:1.0 1:0.0"])  # noqa: E501
     selected = pick_best_chain.PickBestSelected(index=0, probability=1.0, score=0.0)
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context, selected=selected
@@ -111,16 +121,17 @@ def test_pickbest_textembedder_w_full_label_w_embed_and_keep() -> None:
     str1 = "0"
     str2 = "1"
     str3 = "2"
-    encoded_str1 = rl_chain._stringify_embedding(list(encoded_keyword + str1))
-    encoded_str2 = rl_chain._stringify_embedding(list(encoded_keyword + str2))
-    encoded_str3 = rl_chain._stringify_embedding(list(encoded_keyword + str3))
 
-    ctx_str_1 = "context1"
-    encoded_ctx_str_1 = rl_chain._stringify_embedding(list(encoded_keyword + ctx_str_1))
+    ctx_str = "ctx"
+    encoded_ctx_str = "0:3.0 1:0.0"
 
-    named_actions = {"action1": rl_chain.EmbedAndKeep([str1, str2, str3])}
-    context = {"context": rl_chain.EmbedAndKeep(ctx_str_1)}
-    expected = f"""shared |context {ctx_str_1 + " " + encoded_ctx_str_1} \n0:-0.0:1.0 |action1 {str1 + " " + encoded_str1} \n|action1 {str2 + " " + encoded_str2} \n|action1 {str3 + " " + encoded_str3} """  # noqa: E501
+    named_actions = {"action": rl_chain.EmbedAndKeep([str1, str2, str3])}
+    context = {"context": rl_chain.EmbedAndKeep(ctx_str)}
+    expected = "\n".join([
+        f"shared |context_dense {encoded_ctx_str} |context_sparse raw:={ctx_str}",
+        "0:-0.0:1.0 |action_dense 0:1.0 1:0.0 |action_sparse raw:=0",
+        "|action_dense 0:1.0 1:0.0 |action_sparse raw:=1",
+        "|action_dense 0:1.0 1:0.0 |action_sparse raw:=2"])  # noqa: E501
     selected = pick_best_chain.PickBestSelected(index=0, probability=1.0, score=0.0)
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context, selected=selected
@@ -135,7 +146,11 @@ def test_pickbest_textembedder_more_namespaces_no_label_no_emb() -> None:
     )
     named_actions = {"action1": [{"a": "0", "b": "0"}, "1", "2"]}
     context = {"context1": "context1", "context2": "context2"}
-    expected = """shared |context1 context1 |context2 context2 \n|a 0 |b 0 \n|action1 1 \n|action1 2 """  # noqa: E501
+    expected = "\n".join([
+        "shared |context1_sparse raw:=context1 |context2_sparse raw:=context2 ",
+        "|a_sparse raw:=0 |b_sparse raw:=0",
+        "|action1_sparse raw:=1",
+        "|action1_sparse raw:=2"])  # noqa: E501
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context
     )
@@ -147,9 +162,13 @@ def test_pickbest_textembedder_more_namespaces_w_label_no_emb() -> None:
     featurizer = pick_best_chain.PickBestFeaturizer(
         auto_embed=False, model=MockEncoder()
     )
-    named_actions = {"action1": [{"a": "0", "b": "0"}, "1", "2"]}
+    named_actions = {"action": [{"a": "0", "b": "0"}, "1", "2"]}
     context = {"context1": "context1", "context2": "context2"}
-    expected = """shared |context1 context1 |context2 context2 \n|a 0 |b 0 \n|action1 1 \n|action1 2 """  # noqa: E501
+    expected = "\n".join([
+        "shared |context1_sparse raw:=context1 |context2_sparse raw:=context2",
+        "|a_sparse raw:=0 |b_sparse raw:=0",
+        "|action_sparse raw:=1",
+        "|action_sparse raw:=2"])  # noqa: E501
     selected = pick_best_chain.PickBestSelected(index=0, probability=1.0)
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context, selected=selected
@@ -162,9 +181,13 @@ def test_pickbest_textembedder_more_namespaces_w_full_label_no_emb() -> None:
     featurizer = pick_best_chain.PickBestFeaturizer(
         auto_embed=False, model=MockEncoder()
     )
-    named_actions = {"action1": [{"a": "0", "b": "0"}, "1", "2"]}
+    named_actions = {"action": [{"a": "0", "b": "0"}, "1", "2"]}
     context = {"context1": "context1", "context2": "context2"}
-    expected = """shared |context1 context1 |context2 context2 \n0:-0.0:1.0 |a 0 |b 0 \n|action1 1 \n|action1 2 """  # noqa: E501
+    expected = "\n".join([
+        "shared |context1_sparse raw:=context1 |context2_sparse raw:=context2",
+        "0:-0.0:1.0 |a_sparse raw:=0 |b_sparse raw:=0",
+        "|action_sparse raw:=1",
+        "|action_sparse raw:=2"])  # noqa: E501
     selected = pick_best_chain.PickBestSelected(index=0, probability=1.0, score=0.0)
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context, selected=selected
@@ -181,21 +204,22 @@ def test_pickbest_textembedder_more_namespaces_w_full_label_w_full_emb() -> None
     str1 = "0"
     str2 = "1"
     str3 = "2"
-    encoded_str1 = rl_chain._stringify_embedding(list(encoded_keyword + str1))
-    encoded_str2 = rl_chain._stringify_embedding(list(encoded_keyword + str2))
-    encoded_str3 = rl_chain._stringify_embedding(list(encoded_keyword + str3))
 
-    ctx_str_1 = "context1"
-    ctx_str_2 = "context2"
-    encoded_ctx_str_1 = rl_chain._stringify_embedding(list(encoded_keyword + ctx_str_1))
-    encoded_ctx_str_2 = rl_chain._stringify_embedding(list(encoded_keyword + ctx_str_2))
+    ctx_str_1 = "ctx"
+    ctx_str_2 = "ctx_"
+    encoded_ctx_str_1 = "0:3.0 1:0.0"
+    encoded_ctx_str_2 = "0:4.0 1:0.0"
 
-    named_actions = {"action1": rl_chain.Embed([{"a": str1, "b": str1}, str2, str3])}
+    named_actions = {"action": rl_chain.Embed([{"a": str1, "b": str1}, str2, str3])}
     context = {
         "context1": rl_chain.Embed(ctx_str_1),
         "context2": rl_chain.Embed(ctx_str_2),
     }
-    expected = f"""shared |context1 {encoded_ctx_str_1} |context2 {encoded_ctx_str_2} \n0:-0.0:1.0 |a {encoded_str1} |b {encoded_str1} \n|action1 {encoded_str2} \n|action1 {encoded_str3} """  # noqa: E501
+    expected = "\n".join([
+        f"shared |context1_dense {encoded_ctx_str_1} |context2_dense {encoded_ctx_str_2}",
+        f"0:-0.0:1.0 |a_dense 0:1.0 1:0.0 |b_dense 0:1.0 1:0.0",
+        f"|action_dense 0:1.0 1:0.0",
+        f"|action_dense 0:1.0 1:0.0"])  # noqa: E501
 
     selected = pick_best_chain.PickBestSelected(index=0, probability=1.0, score=0.0)
     event = pick_best_chain.PickBestEvent(
@@ -215,24 +239,25 @@ def test_pickbest_textembedder_more_namespaces_w_full_label_w_full_embed_and_kee
     str1 = "0"
     str2 = "1"
     str3 = "2"
-    encoded_str1 = rl_chain._stringify_embedding(list(encoded_keyword + str1))
-    encoded_str2 = rl_chain._stringify_embedding(list(encoded_keyword + str2))
-    encoded_str3 = rl_chain._stringify_embedding(list(encoded_keyword + str3))
 
-    ctx_str_1 = "context1"
-    ctx_str_2 = "context2"
-    encoded_ctx_str_1 = rl_chain._stringify_embedding(list(encoded_keyword + ctx_str_1))
-    encoded_ctx_str_2 = rl_chain._stringify_embedding(list(encoded_keyword + ctx_str_2))
+    ctx_str_1 = "ctx"
+    ctx_str_2 = "ctx_"
+    encoded_ctx_str_1 = "0:3.0 1:0.0"
+    encoded_ctx_str_2 = "0:4.0 1:0.0"
 
     named_actions = {
-        "action1": rl_chain.EmbedAndKeep([{"a": str1, "b": str1}, str2, str3])
+        "action": rl_chain.EmbedAndKeep([{"a": str1, "b": str1}, str2, str3])
     }
     context = {
         "context1": rl_chain.EmbedAndKeep(ctx_str_1),
         "context2": rl_chain.EmbedAndKeep(ctx_str_2),
     }
-    expected = f"""shared |context1 {ctx_str_1 + " " + encoded_ctx_str_1} |context2 {ctx_str_2 + " " + encoded_ctx_str_2} \n0:-0.0:1.0 |a {str1 + " " + encoded_str1} |b {str1 + " " + encoded_str1} \n|action1 {str2 + " " + encoded_str2} \n|action1 {str3 + " " + encoded_str3} """  # noqa: E501
-
+    expected = "\n".join([
+        f"shared |context1_dense {encoded_ctx_str_1} |context2_dense {encoded_ctx_str_2} |context1_sparse raw:={ctx_str_1} |context2_sparse raw:={ctx_str_2}",
+        f"0:-0.0:1.0 |a_dense 0:1.0 1:0.0 |b_dense 0:1.0 1:0.0 |a_sparse raw:=0 |b_sparse raw:=0",
+        f"|action_dense 0:1.0 1:0.0 |action_sparse raw:=1",
+        f"|action_dense 0:1.0 1:0.0 |action_sparse raw:=2"])  # noqa: E501
+    
     selected = pick_best_chain.PickBestSelected(index=0, probability=1.0, score=0.0)
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context, selected=selected
@@ -249,18 +274,21 @@ def test_pickbest_textembedder_more_namespaces_w_full_label_w_partial_emb() -> N
     str1 = "0"
     str2 = "1"
     str3 = "2"
-    encoded_str1 = rl_chain._stringify_embedding(list(encoded_keyword + str1))
-    encoded_str3 = rl_chain._stringify_embedding(list(encoded_keyword + str3))
 
-    ctx_str_1 = "context1"
-    ctx_str_2 = "context2"
-    encoded_ctx_str_2 = rl_chain._stringify_embedding(list(encoded_keyword + ctx_str_2))
+    ctx_str_1 = "ctx"
+    ctx_str_2 = "ctx_"
+    encoded_ctx_str_2 = "0:4.0 1:0.0"
 
     named_actions = {
-        "action1": [{"a": str1, "b": rl_chain.Embed(str1)}, str2, rl_chain.Embed(str3)]
+        "action": [{"a": str1, "b": rl_chain.Embed(str1)}, str2, rl_chain.Embed(str3)]
     }
     context = {"context1": ctx_str_1, "context2": rl_chain.Embed(ctx_str_2)}
-    expected = f"""shared |context1 {ctx_str_1} |context2 {encoded_ctx_str_2} \n0:-0.0:1.0 |a {str1} |b {encoded_str1} \n|action1 {str2} \n|action1 {encoded_str3} """  # noqa: E501
+
+    expected = "\n".join([
+        f"shared |context2_dense {encoded_ctx_str_2} |context1_sparse raw:={ctx_str_1}",
+        f"0:-0.0:1.0 |b_dense 0:1.0 1:0.0 |a_sparse raw:=0",
+        f"|action_sparse raw:=1",
+        f"|action_dense 0:1.0 1:0.0"])  # noqa: E501
 
     selected = pick_best_chain.PickBestSelected(index=0, probability=1.0, score=0.0)
     event = pick_best_chain.PickBestEvent(
@@ -278,23 +306,24 @@ def test_pickbest_textembedder_more_namespaces_w_full_label_w_partial_emakeep() 
     str1 = "0"
     str2 = "1"
     str3 = "2"
-    encoded_str1 = rl_chain._stringify_embedding(list(encoded_keyword + str1))
-    encoded_str3 = rl_chain._stringify_embedding(list(encoded_keyword + str3))
 
-    ctx_str_1 = "context1"
-    ctx_str_2 = "context2"
-    encoded_ctx_str_2 = rl_chain._stringify_embedding(list(encoded_keyword + ctx_str_2))
+    ctx_str_1 = "ctx"
+    ctx_str_2 = "ctx_"
+    encoded_ctx_str_2 = "0:4.0 1:0.0"
 
     named_actions = {
-        "action1": [
+        "action": [
             {"a": str1, "b": rl_chain.EmbedAndKeep(str1)},
             str2,
             rl_chain.EmbedAndKeep(str3),
         ]
     }
     context = {"context1": ctx_str_1, "context2": rl_chain.EmbedAndKeep(ctx_str_2)}
-    expected = f"""shared |context1 {ctx_str_1} |context2 {ctx_str_2 + " " + encoded_ctx_str_2} \n0:-0.0:1.0 |a {str1} |b {str1 + " " + encoded_str1} \n|action1 {str2} \n|action1 {str3 + " " + encoded_str3} """  # noqa: E501
-
+    expected = "\n".join([
+        f"shared |context2_dense {encoded_ctx_str_2} |context1_sparse raw:={ctx_str_1} |context2_sparse raw:={ctx_str_2}",
+        f"0:-0.0:1.0 |b_dense 0:1.0 1:0.0 |a_sparse raw:=0 |b_sparse raw:=0",
+        f"|action_sparse raw:=1",
+        f"|action_dense 0:1.0 1:0.0 |action_sparse raw:=2"])  # noqa: E501
     selected = pick_best_chain.PickBestSelected(index=0, probability=1.0, score=0.0)
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context, selected=selected
@@ -309,18 +338,19 @@ def test_raw_features_underscored() -> None:
     )
     str1 = "this is a long string"
     str1_underscored = str1.replace(" ", "_")
-    encoded_str1 = rl_chain._stringify_embedding(list(encoded_keyword + str1))
+    encoded_str1 = f"0:{float(len(str1))} 1:0.0"
 
     ctx_str = "this is a long context"
     ctx_str_underscored = ctx_str.replace(" ", "_")
-    encoded_ctx_str = rl_chain._stringify_embedding(list(encoded_keyword + ctx_str))
+    encoded_ctx_str = f"0:{float(len(ctx_str))} 1:0.0"
 
     # No embeddings
     named_actions = {"action": [str1]}
     context = {"context": ctx_str}
-    expected_no_embed = (
-        f"""shared |context {ctx_str_underscored} \n|action {str1_underscored} """
-    )
+    expected_no_embed = "\n".join([
+        f"shared |context_sparse raw:={ctx_str_underscored}",
+        f"|action_sparse raw:={str1_underscored}"])
+    
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context
     )
@@ -330,7 +360,9 @@ def test_raw_features_underscored() -> None:
     # Just embeddings
     named_actions = {"action": rl_chain.Embed([str1])}
     context = {"context": rl_chain.Embed(ctx_str)}
-    expected_embed = f"""shared |context {encoded_ctx_str} \n|action {encoded_str1} """
+    expected_embed = "\n".join([
+        f"shared |context_dense {encoded_ctx_str}",
+        f"|action_dense {encoded_str1}"])
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context
     )
@@ -340,7 +372,9 @@ def test_raw_features_underscored() -> None:
     # Embeddings and raw features
     named_actions = {"action": rl_chain.EmbedAndKeep([str1])}
     context = {"context": rl_chain.EmbedAndKeep(ctx_str)}
-    expected_embed_and_keep = f"""shared |context {ctx_str_underscored + " " + encoded_ctx_str} \n|action {str1_underscored + " " + encoded_str1} """  # noqa: E501
+    expected_embed_and_keep = "\n".join([
+        f"shared |context_dense {encoded_ctx_str} |context_sparse raw:={ctx_str_underscored}",
+        f"|action_dense {encoded_str1} |action_sparse raw:={str1_underscored}"])  # noqa: E501
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context
     )

--- a/tests/unit_tests/test_pick_best_text_embedder.py
+++ b/tests/unit_tests/test_pick_best_text_embedder.py
@@ -3,6 +3,7 @@ from test_utils import MockEncoder, assert_vw_ex_equals
 
 import learn_to_pick.base as rl_chain
 import learn_to_pick.pick_best as pick_best_chain
+from learn_to_pick.pick_best import vw_cb_formatter
 
 
 def test_pickbest_textembedder_missing_context_not_throws() -> None:
@@ -13,7 +14,7 @@ def test_pickbest_textembedder_missing_context_not_throws() -> None:
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_action, based_on={}
     )
-    featurizer.format(event)
+    featurizer.featurize(event)
 
 
 def test_pickbest_textembedder_missing_actions_throws() -> None:
@@ -24,7 +25,7 @@ def test_pickbest_textembedder_missing_actions_throws() -> None:
         inputs={}, to_select_from={}, based_on={"context": "context"}
     )
     with pytest.raises(ValueError):
-        featurizer.format(event)
+        featurizer.featurize(event)
 
 
 def test_pickbest_textembedder_no_label_no_emb() -> None:
@@ -41,7 +42,7 @@ def test_pickbest_textembedder_no_label_no_emb() -> None:
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on={"context": "context"}
     )
-    vw_ex_str = featurizer.format(event)
+    vw_ex_str = vw_cb_formatter(*featurizer.featurize(event))
     assert_vw_ex_equals(vw_ex_str, expected)
 
 
@@ -62,7 +63,7 @@ def test_pickbest_textembedder_w_label_no_score_no_emb() -> None:
         based_on={"context": "context"},
         selected=selected,
     )
-    vw_ex_str = featurizer.format(event)
+    vw_ex_str = vw_cb_formatter(*featurizer.featurize(event))
     assert_vw_ex_equals(vw_ex_str, expected)
 
 
@@ -84,7 +85,7 @@ def test_pickbest_textembedder_w_full_label_no_emb() -> None:
         based_on={"context": "context"},
         selected=selected,
     )
-    vw_ex_str = featurizer.format(event)
+    vw_ex_str = vw_cb_formatter(*featurizer.featurize(event))
     assert_vw_ex_equals(vw_ex_str, expected)
 
 
@@ -110,7 +111,7 @@ def test_pickbest_textembedder_w_full_label_w_emb() -> None:
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context, selected=selected
     )
-    vw_ex_str = featurizer.format(event)
+    vw_ex_str = vw_cb_formatter(*featurizer.featurize(event))
     assert_vw_ex_equals(vw_ex_str, expected)
 
 
@@ -136,7 +137,7 @@ def test_pickbest_textembedder_w_full_label_w_embed_and_keep() -> None:
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context, selected=selected
     )
-    vw_ex_str = featurizer.format(event)
+    vw_ex_str = vw_cb_formatter(*featurizer.featurize(event))
     assert_vw_ex_equals(vw_ex_str, expected)
 
 
@@ -154,7 +155,7 @@ def test_pickbest_textembedder_more_namespaces_no_label_no_emb() -> None:
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context
     )
-    vw_ex_str = featurizer.format(event)
+    vw_ex_str = vw_cb_formatter(*featurizer.featurize(event))
     assert_vw_ex_equals(vw_ex_str, expected)
 
 
@@ -173,7 +174,7 @@ def test_pickbest_textembedder_more_namespaces_w_label_no_emb() -> None:
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context, selected=selected
     )
-    vw_ex_str = featurizer.format(event)
+    vw_ex_str = vw_cb_formatter(*featurizer.featurize(event))
     assert_vw_ex_equals(vw_ex_str, expected)
 
 
@@ -192,7 +193,7 @@ def test_pickbest_textembedder_more_namespaces_w_full_label_no_emb() -> None:
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context, selected=selected
     )
-    vw_ex_str = featurizer.format(event)
+    vw_ex_str = vw_cb_formatter(*featurizer.featurize(event))
     assert_vw_ex_equals(vw_ex_str, expected)
 
 
@@ -225,7 +226,7 @@ def test_pickbest_textembedder_more_namespaces_w_full_label_w_full_emb() -> None
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context, selected=selected
     )
-    vw_ex_str = featurizer.format(event)
+    vw_ex_str = vw_cb_formatter(*featurizer.featurize(event))
     assert_vw_ex_equals(vw_ex_str, expected)
 
 
@@ -262,7 +263,7 @@ def test_pickbest_textembedder_more_namespaces_w_full_label_w_full_embed_and_kee
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context, selected=selected
     )
-    vw_ex_str = featurizer.format(event)
+    vw_ex_str = vw_cb_formatter(*featurizer.featurize(event))
     assert_vw_ex_equals(vw_ex_str, expected)
 
 
@@ -294,7 +295,7 @@ def test_pickbest_textembedder_more_namespaces_w_full_label_w_partial_emb() -> N
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context, selected=selected
     )
-    vw_ex_str = featurizer.format(event)
+    vw_ex_str = vw_cb_formatter(*featurizer.featurize(event))
     assert_vw_ex_equals(vw_ex_str, expected)
 
 
@@ -328,7 +329,7 @@ def test_pickbest_textembedder_more_namespaces_w_full_label_w_partial_emakeep() 
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context, selected=selected
     )
-    vw_ex_str = featurizer.format(event)
+    vw_ex_str = vw_cb_formatter(*featurizer.featurize(event))
     assert_vw_ex_equals(vw_ex_str, expected)
 
 
@@ -354,7 +355,7 @@ def test_raw_features_underscored() -> None:
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context
     )
-    vw_ex_str = featurizer.format(event)
+    vw_ex_str = vw_cb_formatter(*featurizer.featurize(event))
     assert_vw_ex_equals(vw_ex_str, expected_no_embed)
 
     # Just embeddings
@@ -366,7 +367,7 @@ def test_raw_features_underscored() -> None:
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context
     )
-    vw_ex_str = featurizer.format(event)
+    vw_ex_str = vw_cb_formatter(*featurizer.featurize(event))
     assert_vw_ex_equals(vw_ex_str, expected_embed)
 
     # Embeddings and raw features
@@ -378,5 +379,5 @@ def test_raw_features_underscored() -> None:
     event = pick_best_chain.PickBestEvent(
         inputs={}, to_select_from=named_actions, based_on=context
     )
-    vw_ex_str = featurizer.format(event)
+    vw_ex_str = vw_cb_formatter(*featurizer.featurize(event))
     assert_vw_ex_equals(vw_ex_str, expected_embed_and_keep)

--- a/tests/unit_tests/test_rl_loop_base_embedder.py
+++ b/tests/unit_tests/test_rl_loop_base_embedder.py
@@ -362,9 +362,18 @@ def test_action_w_namespace_w_emb_w_more_than_one_item_in_first_dict() -> None:
         assert featurized[i].dense == expected_dense[i]
 
     expected_sparse = [
-        {"test_namespace": {"default_ft": str1}, "test_namespace2": {"default_ft": str1}},
-        {"test_namespace": {"default_ft": str2}, "test_namespace2": {"default_ft": str2}},
-        {"test_namespace": {"default_ft": str3}, "test_namespace2": {"default_ft": str3}},
+        {
+            "test_namespace": {"default_ft": str1},
+            "test_namespace2": {"default_ft": str1},
+        },
+        {
+            "test_namespace": {"default_ft": str2},
+            "test_namespace2": {"default_ft": str2},
+        },
+        {
+            "test_namespace": {"default_ft": str3},
+            "test_namespace2": {"default_ft": str3},
+        },
     ]
     featurized = base.embed(
         [

--- a/tests/unit_tests/test_rl_loop_base_embedder.py
+++ b/tests/unit_tests/test_rl_loop_base_embedder.py
@@ -7,7 +7,7 @@ import learn_to_pick.base as base
 
 
 def test_simple_context_str_no_emb() -> None:
-    expected = {"a_namespace": {"raw": "test"}}
+    expected = {"a_namespace": {"default_ft": "test"}}
 
     featurized = base.embed("test", MockEncoder(), "a_namespace")
     assert featurized.sparse == expected
@@ -17,7 +17,7 @@ def test_simple_context_str_no_emb() -> None:
 def test_simple_context_str_w_emb() -> None:
     str1 = "test"
     expected_dense = {"a_namespace": [4.0, 0.0]}
-    expected_sparse = {"a_namespace": {"raw": str1}}
+    expected_sparse = {"a_namespace": {"default_ft": str1}}
 
     featurized = base.embed(base.Embed(str1), MockEncoder(), "a_namespace")
     assert featurized.dense == expected_dense
@@ -32,7 +32,7 @@ def test_simple_context_str_w_nested_emb() -> None:
     # nested embeddings, innermost wins
     str1 = "test"
     expected_dense = {"a_namespace": [4.0, 0.0]}
-    expected_sparse = {"a_namespace": {"raw": str1}}
+    expected_sparse = {"a_namespace": {"default_ft": str1}}
 
     featurized = base.embed(
         base.EmbedAndKeep(base.Embed(str1)), MockEncoder(), "a_namespace"
@@ -48,7 +48,7 @@ def test_simple_context_str_w_nested_emb() -> None:
 
 
 def test_context_w_namespace_no_emb() -> None:
-    expected_sparse = {"test_namespace": {"raw": "test"}}
+    expected_sparse = {"test_namespace": {"default_ft": "test"}}
     featurized = base.embed({"test_namespace": "test"}, MockEncoder())
     assert featurized.sparse == expected_sparse
     assert featurized.dense == {}
@@ -56,7 +56,7 @@ def test_context_w_namespace_no_emb() -> None:
 
 def test_context_w_namespace_w_emb() -> None:
     str1 = "test"
-    expected_sparse = {"test_namespace": {"raw": str1}}
+    expected_sparse = {"test_namespace": {"default_ft": str1}}
     expected_dense = {"test_namespace": [4.0, 0.0]}
 
     featurized = base.embed({"test_namespace": base.Embed(str1)}, MockEncoder())
@@ -70,7 +70,7 @@ def test_context_w_namespace_w_emb() -> None:
 
 def test_context_w_namespace_w_emb2() -> None:
     str1 = "test"
-    expected_sparse = {"test_namespace": {"raw": str1}}
+    expected_sparse = {"test_namespace": {"default_ft": str1}}
     expected_dense = {"test_namespace": [4.0, 0.0]}
 
     featurized = base.embed(base.Embed({"test_namespace": str1}), MockEncoder())
@@ -85,7 +85,7 @@ def test_context_w_namespace_w_emb2() -> None:
 def test_context_w_namespace_w_some_emb() -> None:
     str1 = "test"
     str2 = "test_"
-    expected_sparse = {"test_namespace": {"raw": str1}}
+    expected_sparse = {"test_namespace": {"default_ft": str1}}
     expected_dense = {"test_namespace2": [5.0, 0.0]}
     featurized = base.embed(
         {"test_namespace": str1, "test_namespace2": base.Embed(str2)}, MockEncoder()
@@ -94,8 +94,8 @@ def test_context_w_namespace_w_some_emb() -> None:
     assert featurized.dense == expected_dense
 
     expected_sparse = {
-        "test_namespace": {"raw": str1},
-        "test_namespace2": {"raw": str2},
+        "test_namespace": {"default_ft": str1},
+        "test_namespace2": {"default_ft": str2},
     }
     featurized = base.embed(
         {"test_namespace": str1, "test_namespace2": base.EmbedAndKeep(str2)},
@@ -110,9 +110,9 @@ def test_simple_action_strlist_no_emb() -> None:
     str2 = "test2"
     str3 = "test3"
     expected_sparse = [
-        {"a_namespace": {"raw": str1}},
-        {"a_namespace": {"raw": str2}},
-        {"a_namespace": {"raw": str3}},
+        {"a_namespace": {"default_ft": str1}},
+        {"a_namespace": {"default_ft": str2}},
+        {"a_namespace": {"default_ft": str3}},
     ]
     to_embed: List[Union[str, base._Embed]] = [str1, str2, str3]
     featurized = base.embed(to_embed, MockEncoder(), "a_namespace")
@@ -128,9 +128,9 @@ def test_simple_action_strlist_w_emb() -> None:
     str3 = "test__"
 
     expected_sparse = [
-        {"a_namespace": {"raw": str1}},
-        {"a_namespace": {"raw": str2}},
-        {"a_namespace": {"raw": str3}},
+        {"a_namespace": {"default_ft": str1}},
+        {"a_namespace": {"default_ft": str2}},
+        {"a_namespace": {"default_ft": str3}},
     ]
     expected_dense = [
         {"a_namespace": [4.0, 0.0]},
@@ -158,7 +158,7 @@ def test_simple_action_strlist_w_some_emb() -> None:
     str2 = "test_"
     str3 = "test__"
 
-    expected_sparse = [{"a_namespace": {"raw": str1}}, {}, {}]
+    expected_sparse = [{"a_namespace": {"default_ft": str1}}, {}, {}]
     expected_dense = [{}, {"a_namespace": [5.0, 0.0]}, {"a_namespace": [6.0, 0.0]}]
     featurized = base.embed(
         [str1, base.Embed(str2), base.Embed(str3)], MockEncoder(), "a_namespace"
@@ -173,9 +173,9 @@ def test_simple_action_strlist_w_some_emb() -> None:
         "a_namespace",
     )
     expected_sparse = [
-        {"a_namespace": {"raw": str1}},
-        {"a_namespace": {"raw": str2}},
-        {"a_namespace": {"raw": str3}},
+        {"a_namespace": {"default_ft": str1}},
+        {"a_namespace": {"default_ft": str2}},
+        {"a_namespace": {"default_ft": str3}},
     ]
     for i in range(len(featurized)):
         assert featurized[i].sparse == expected_sparse[i]
@@ -187,9 +187,9 @@ def test_action_w_namespace_no_emb() -> None:
     str2 = "test2"
     str3 = "test3"
     expected_sparse = [
-        {"test_namespace": {"raw": str1}},
-        {"test_namespace": {"raw": str2}},
-        {"test_namespace": {"raw": str3}},
+        {"test_namespace": {"default_ft": str1}},
+        {"test_namespace": {"default_ft": str2}},
+        {"test_namespace": {"default_ft": str3}},
     ]
 
     featurized = base.embed(
@@ -210,9 +210,9 @@ def test_action_w_namespace_w_emb() -> None:
     str2 = "test_"
     str3 = "test__"
     expected_sparse = [
-        {"test_namespace": {"raw": str1}},
-        {"test_namespace": {"raw": str2}},
-        {"test_namespace": {"raw": str3}},
+        {"test_namespace": {"default_ft": str1}},
+        {"test_namespace": {"default_ft": str2}},
+        {"test_namespace": {"default_ft": str3}},
     ]
     expected_dense = [
         {"test_namespace": [4.0, 0.0]},
@@ -250,9 +250,9 @@ def test_action_w_namespace_w_emb2() -> None:
     str2 = "test_"
     str3 = "test__"
     expected_sparse = [
-        {"test_namespace1": {"raw": str1}},
-        {"test_namespace2": {"raw": str2}},
-        {"test_namespace3": {"raw": str3}},
+        {"test_namespace1": {"default_ft": str1}},
+        {"test_namespace2": {"default_ft": str2}},
+        {"test_namespace3": {"default_ft": str3}},
     ]
     expected_dense = [
         {"test_namespace1": [4.0, 0.0]},
@@ -294,7 +294,7 @@ def test_action_w_namespace_w_some_emb() -> None:
     str2 = "test_"
     str3 = "test__"
     expected_sparse = [
-        {"test_namespace": {"raw": str1}},
+        {"test_namespace": {"default_ft": str1}},
         {},
         {},
     ]
@@ -317,9 +317,9 @@ def test_action_w_namespace_w_some_emb() -> None:
         assert featurized[i].dense == expected_dense[i]
 
     expected_sparse = [
-        {"test_namespace": {"raw": str1}},
-        {"test_namespace": {"raw": str2}},
-        {"test_namespace": {"raw": str3}},
+        {"test_namespace": {"default_ft": str1}},
+        {"test_namespace": {"default_ft": str2}},
+        {"test_namespace": {"default_ft": str3}},
     ]
     featurized = base.embed(
         [
@@ -339,9 +339,9 @@ def test_action_w_namespace_w_emb_w_more_than_one_item_in_first_dict() -> None:
     str2 = "test_"
     str3 = "test__"
     expected_sparse = [
-        {"test_namespace2": {"raw": str1}},
-        {"test_namespace2": {"raw": str2}},
-        {"test_namespace2": {"raw": str3}},
+        {"test_namespace2": {"default_ft": str1}},
+        {"test_namespace2": {"default_ft": str2}},
+        {"test_namespace2": {"default_ft": str3}},
     ]
     expected_dense = [
         {"test_namespace": [4.0, 0.0]},
@@ -362,9 +362,9 @@ def test_action_w_namespace_w_emb_w_more_than_one_item_in_first_dict() -> None:
         assert featurized[i].dense == expected_dense[i]
 
     expected_sparse = [
-        {"test_namespace": {"raw": str1}, "test_namespace2": {"raw": str1}},
-        {"test_namespace": {"raw": str2}, "test_namespace2": {"raw": str2}},
-        {"test_namespace": {"raw": str3}, "test_namespace2": {"raw": str3}},
+        {"test_namespace": {"default_ft": str1}, "test_namespace2": {"default_ft": str1}},
+        {"test_namespace": {"default_ft": str2}, "test_namespace2": {"default_ft": str2}},
+        {"test_namespace": {"default_ft": str3}, "test_namespace2": {"default_ft": str3}},
     ]
     featurized = base.embed(
         [
@@ -383,8 +383,8 @@ def test_one_namespace_w_list_of_features_no_emb() -> None:
     str1 = "test1"
     str2 = "test2"
     expected_sparse = {
-        "test_namespace_0": {"raw": str1},
-        "test_namespace_1": {"raw": str2},
+        "test_namespace_0": {"default_ft": str1},
+        "test_namespace_1": {"default_ft": str2},
     }
 
     featurized = base.embed({"test_namespace": [str1, str2]}, MockEncoder())
@@ -395,7 +395,7 @@ def test_one_namespace_w_list_of_features_no_emb() -> None:
 def test_one_namespace_w_list_of_features_w_some_emb() -> None:
     str1 = "test"
     str2 = "test_"
-    expected_sparse = {"test_namespace_0": {"raw": str1}}
+    expected_sparse = {"test_namespace_0": {"default_ft": str1}}
     expected_dense = {"test_namespace_1": [5.0, 0.0]}
 
     featurized = base.embed({"test_namespace": [str1, base.Embed(str2)]}, MockEncoder())

--- a/tests/unit_tests/test_rl_loop_base_embedder.py
+++ b/tests/unit_tests/test_rl_loop_base_embedder.py
@@ -34,11 +34,15 @@ def test_simple_context_str_w_nested_emb() -> None:
     expected_dense = {"a_namespace": [4.0, 0.0]}
     expected_sparse = {"a_namespace": {"raw": str1}}
 
-    featurized = base.embed(base.EmbedAndKeep(base.Embed(str1)), MockEncoder(), "a_namespace")
+    featurized = base.embed(
+        base.EmbedAndKeep(base.Embed(str1)), MockEncoder(), "a_namespace"
+    )
     assert featurized.dense == expected_dense
     assert featurized.sparse == {}
 
-    featurized = base.embed(base.Embed(base.EmbedAndKeep(str1)), MockEncoder(), "a_namespace")
+    featurized = base.embed(
+        base.Embed(base.EmbedAndKeep(str1)), MockEncoder(), "a_namespace"
+    )
     assert featurized.sparse == expected_sparse
     assert featurized.dense == expected_dense
 
@@ -48,6 +52,7 @@ def test_context_w_namespace_no_emb() -> None:
     featurized = base.embed({"test_namespace": "test"}, MockEncoder())
     assert featurized.sparse == expected_sparse
     assert featurized.dense == {}
+
 
 def test_context_w_namespace_w_emb() -> None:
     str1 = "test"
@@ -67,7 +72,7 @@ def test_context_w_namespace_w_emb2() -> None:
     str1 = "test"
     expected_sparse = {"test_namespace": {"raw": str1}}
     expected_dense = {"test_namespace": [4.0, 0.0]}
-    
+
     featurized = base.embed(base.Embed({"test_namespace": str1}), MockEncoder())
     assert featurized.sparse == {}
     assert featurized.dense == expected_dense
@@ -83,16 +88,19 @@ def test_context_w_namespace_w_some_emb() -> None:
     expected_sparse = {"test_namespace": {"raw": str1}}
     expected_dense = {"test_namespace2": [5.0, 0.0]}
     featurized = base.embed(
-            {"test_namespace": str1, "test_namespace2": base.Embed(str2)}, MockEncoder()
-        )
+        {"test_namespace": str1, "test_namespace2": base.Embed(str2)}, MockEncoder()
+    )
     assert featurized.sparse == expected_sparse
     assert featurized.dense == expected_dense
 
-    expected_sparse = {"test_namespace": {"raw": str1}, "test_namespace2": {"raw": str2}}
+    expected_sparse = {
+        "test_namespace": {"raw": str1},
+        "test_namespace2": {"raw": str2},
+    }
     featurized = base.embed(
-            {"test_namespace": str1, "test_namespace2": base.EmbedAndKeep(str2)},
-            MockEncoder(),
-        )
+        {"test_namespace": str1, "test_namespace2": base.EmbedAndKeep(str2)},
+        MockEncoder(),
+    )
     assert featurized.sparse == expected_sparse
     assert featurized.dense == expected_dense
 
@@ -104,7 +112,8 @@ def test_simple_action_strlist_no_emb() -> None:
     expected_sparse = [
         {"a_namespace": {"raw": str1}},
         {"a_namespace": {"raw": str2}},
-        {"a_namespace": {"raw": str3}}]
+        {"a_namespace": {"raw": str3}},
+    ]
     to_embed: List[Union[str, base._Embed]] = [str1, str2, str3]
     featurized = base.embed(to_embed, MockEncoder(), "a_namespace")
 
@@ -121,18 +130,24 @@ def test_simple_action_strlist_w_emb() -> None:
     expected_sparse = [
         {"a_namespace": {"raw": str1}},
         {"a_namespace": {"raw": str2}},
-        {"a_namespace": {"raw": str3}}]
+        {"a_namespace": {"raw": str3}},
+    ]
     expected_dense = [
         {"a_namespace": [4.0, 0.0]},
         {"a_namespace": [5.0, 0.0]},
-        {"a_namespace": [6.0, 0.0]}]
-    
-    featurized = base.embed(base.Embed([str1, str2, str3]), MockEncoder(), "a_namespace")
+        {"a_namespace": [6.0, 0.0]},
+    ]
+
+    featurized = base.embed(
+        base.Embed([str1, str2, str3]), MockEncoder(), "a_namespace"
+    )
     for i in range(len(featurized)):
         assert featurized[i].sparse == {}
         assert featurized[i].dense == expected_dense[i]
 
-    featurized = base.embed(base.EmbedAndKeep([str1, str2, str3]), MockEncoder(), "a_namespace")
+    featurized = base.embed(
+        base.EmbedAndKeep([str1, str2, str3]), MockEncoder(), "a_namespace"
+    )
     for i in range(len(featurized)):
         assert featurized[i].sparse == expected_sparse[i]
         assert featurized[i].dense == expected_dense[i]
@@ -143,24 +158,25 @@ def test_simple_action_strlist_w_some_emb() -> None:
     str2 = "test_"
     str3 = "test__"
 
-    expected_sparse = [
-        {"a_namespace": {"raw": str1}},
-        {},
-        {}]
-    expected_dense = [
-        {},
-        {"a_namespace": [5.0, 0.0]},
-        {"a_namespace": [6.0, 0.0]}]
-    featurized = base.embed([str1, base.Embed(str2), base.Embed(str3)], MockEncoder(), "a_namespace")
+    expected_sparse = [{"a_namespace": {"raw": str1}}, {}, {}]
+    expected_dense = [{}, {"a_namespace": [5.0, 0.0]}, {"a_namespace": [6.0, 0.0]}]
+    featurized = base.embed(
+        [str1, base.Embed(str2), base.Embed(str3)], MockEncoder(), "a_namespace"
+    )
     for i in range(len(featurized)):
         assert featurized[i].sparse == expected_sparse[i]
         assert featurized[i].dense == expected_dense[i]
 
-    featurized = base.embed([str1, base.EmbedAndKeep(str2), base.EmbedAndKeep(str3)], MockEncoder(), "a_namespace")
+    featurized = base.embed(
+        [str1, base.EmbedAndKeep(str2), base.EmbedAndKeep(str3)],
+        MockEncoder(),
+        "a_namespace",
+    )
     expected_sparse = [
         {"a_namespace": {"raw": str1}},
         {"a_namespace": {"raw": str2}},
-        {"a_namespace": {"raw": str3}}]
+        {"a_namespace": {"raw": str3}},
+    ]
     for i in range(len(featurized)):
         assert featurized[i].sparse == expected_sparse[i]
         assert featurized[i].dense == expected_dense[i]
@@ -177,13 +193,13 @@ def test_action_w_namespace_no_emb() -> None:
     ]
 
     featurized = base.embed(
-            [
-                {"test_namespace": str1},
-                {"test_namespace": str2},
-                {"test_namespace": str3},
-            ],
-            MockEncoder(),
-        )
+        [
+            {"test_namespace": str1},
+            {"test_namespace": str2},
+            {"test_namespace": str3},
+        ],
+        MockEncoder(),
+    )
     for i in range(len(featurized)):
         assert featurized[i].sparse == expected_sparse[i]
         assert featurized[i].dense == {}
@@ -201,32 +217,32 @@ def test_action_w_namespace_w_emb() -> None:
     expected_dense = [
         {"test_namespace": [4.0, 0.0]},
         {"test_namespace": [5.0, 0.0]},
-        {"test_namespace": [6.0, 0.0]}]
+        {"test_namespace": [6.0, 0.0]},
+    ]
 
     featurized = base.embed(
-            [
-                {"test_namespace": base.Embed(str1)},
-                {"test_namespace": base.Embed(str2)},
-                {"test_namespace": base.Embed(str3)},
-            ],
-            MockEncoder(),
-        )
+        [
+            {"test_namespace": base.Embed(str1)},
+            {"test_namespace": base.Embed(str2)},
+            {"test_namespace": base.Embed(str3)},
+        ],
+        MockEncoder(),
+    )
     for i in range(len(featurized)):
         assert featurized[i].sparse == {}
         assert featurized[i].dense == expected_dense[i]
 
     featurized = base.embed(
-            [
-                {"test_namespace": base.EmbedAndKeep(str1)},
-                {"test_namespace": base.EmbedAndKeep(str2)},
-                {"test_namespace": base.EmbedAndKeep(str3)},
-            ],
-            MockEncoder(),
-        )
+        [
+            {"test_namespace": base.EmbedAndKeep(str1)},
+            {"test_namespace": base.EmbedAndKeep(str2)},
+            {"test_namespace": base.EmbedAndKeep(str3)},
+        ],
+        MockEncoder(),
+    )
     for i in range(len(featurized)):
         assert featurized[i].sparse == expected_sparse[i]
         assert featurized[i].dense == expected_dense[i]
-
 
 
 def test_action_w_namespace_w_emb2() -> None:
@@ -241,32 +257,33 @@ def test_action_w_namespace_w_emb2() -> None:
     expected_dense = [
         {"test_namespace1": [4.0, 0.0]},
         {"test_namespace2": [5.0, 0.0]},
-        {"test_namespace3": [6.0, 0.0]}]
-    
+        {"test_namespace3": [6.0, 0.0]},
+    ]
+
     featurized = base.embed(
-                base.Embed(
-                    [
-                        {"test_namespace1": str1},
-                        {"test_namespace2": str2},
-                        {"test_namespace3": str3},
-                    ]
-                ),
-                MockEncoder(),
-            )
+        base.Embed(
+            [
+                {"test_namespace1": str1},
+                {"test_namespace2": str2},
+                {"test_namespace3": str3},
+            ]
+        ),
+        MockEncoder(),
+    )
     for i in range(len(featurized)):
         assert featurized[i].sparse == {}
         assert featurized[i].dense == expected_dense[i]
 
     featurized = base.embed(
-            base.EmbedAndKeep(
-                [
-                    {"test_namespace1": str1},
-                    {"test_namespace2": str2},
-                    {"test_namespace3": str3},
-                ]
-            ),
-            MockEncoder(),
-        )
+        base.EmbedAndKeep(
+            [
+                {"test_namespace1": str1},
+                {"test_namespace2": str2},
+                {"test_namespace3": str3},
+            ]
+        ),
+        MockEncoder(),
+    )
     for i in range(len(featurized)):
         assert featurized[i].sparse == expected_sparse[i]
         assert featurized[i].dense == expected_dense[i]
@@ -284,33 +301,34 @@ def test_action_w_namespace_w_some_emb() -> None:
     expected_dense = [
         {},
         {"test_namespace": [5.0, 0.0]},
-        {"test_namespace": [6.0, 0.0]}]
-    
+        {"test_namespace": [6.0, 0.0]},
+    ]
+
     featurized = base.embed(
-            [
-                {"test_namespace": str1},
-                {"test_namespace": base.Embed(str2)},
-                {"test_namespace": base.Embed(str3)},
-            ],
-            MockEncoder(),
-        )
+        [
+            {"test_namespace": str1},
+            {"test_namespace": base.Embed(str2)},
+            {"test_namespace": base.Embed(str3)},
+        ],
+        MockEncoder(),
+    )
     for i in range(len(featurized)):
         assert featurized[i].sparse == expected_sparse[i]
         assert featurized[i].dense == expected_dense[i]
-    
+
     expected_sparse = [
         {"test_namespace": {"raw": str1}},
         {"test_namespace": {"raw": str2}},
         {"test_namespace": {"raw": str3}},
     ]
     featurized = base.embed(
-            [
-                {"test_namespace": str1},
-                {"test_namespace": base.EmbedAndKeep(str2)},
-                {"test_namespace": base.EmbedAndKeep(str3)},
-            ],
-            MockEncoder(),
-        )
+        [
+            {"test_namespace": str1},
+            {"test_namespace": base.EmbedAndKeep(str2)},
+            {"test_namespace": base.EmbedAndKeep(str3)},
+        ],
+        MockEncoder(),
+    )
     for i in range(len(featurized)):
         assert featurized[i].sparse == expected_sparse[i]
         assert featurized[i].dense == expected_dense[i]
@@ -328,16 +346,17 @@ def test_action_w_namespace_w_emb_w_more_than_one_item_in_first_dict() -> None:
     expected_dense = [
         {"test_namespace": [4.0, 0.0]},
         {"test_namespace": [5.0, 0.0]},
-        {"test_namespace": [6.0, 0.0]}]
-    
+        {"test_namespace": [6.0, 0.0]},
+    ]
+
     featurized = base.embed(
-            [
-                {"test_namespace": base.Embed(str1), "test_namespace2": str1},
-                {"test_namespace": base.Embed(str2), "test_namespace2": str2},
-                {"test_namespace": base.Embed(str3), "test_namespace2": str3},
-            ],
-            MockEncoder(),
-        )
+        [
+            {"test_namespace": base.Embed(str1), "test_namespace2": str1},
+            {"test_namespace": base.Embed(str2), "test_namespace2": str2},
+            {"test_namespace": base.Embed(str3), "test_namespace2": str3},
+        ],
+        MockEncoder(),
+    )
     for i in range(len(featurized)):
         assert featurized[i].sparse == expected_sparse[i]
         assert featurized[i].dense == expected_dense[i]
@@ -348,13 +367,13 @@ def test_action_w_namespace_w_emb_w_more_than_one_item_in_first_dict() -> None:
         {"test_namespace": {"raw": str3}, "test_namespace2": {"raw": str3}},
     ]
     featurized = base.embed(
-            [
-                {"test_namespace": base.EmbedAndKeep(str1), "test_namespace2": str1},
-                {"test_namespace": base.EmbedAndKeep(str2), "test_namespace2": str2},
-                {"test_namespace": base.EmbedAndKeep(str3), "test_namespace2": str3},
-            ],
-            MockEncoder(),
-        )
+        [
+            {"test_namespace": base.EmbedAndKeep(str1), "test_namespace2": str1},
+            {"test_namespace": base.EmbedAndKeep(str2), "test_namespace2": str2},
+            {"test_namespace": base.EmbedAndKeep(str3), "test_namespace2": str3},
+        ],
+        MockEncoder(),
+    )
     for i in range(len(featurized)):
         assert featurized[i].sparse == expected_sparse[i]
         assert featurized[i].dense == expected_dense[i]
@@ -365,7 +384,8 @@ def test_one_namespace_w_list_of_features_no_emb() -> None:
     str2 = "test2"
     expected_sparse = {
         "test_namespace_0": {"raw": str1},
-        "test_namespace_1": {"raw": str2}}
+        "test_namespace_1": {"raw": str2},
+    }
 
     featurized = base.embed({"test_namespace": [str1, str2]}, MockEncoder())
     assert featurized.sparse == expected_sparse

--- a/tests/unit_tests/test_rl_loop_base_embedder.py
+++ b/tests/unit_tests/test_rl_loop_base_embedder.py
@@ -5,174 +5,178 @@ from test_utils import MockEncoder
 
 import learn_to_pick.base as base
 
-encoded_keyword = "[encoded]"
-
 
 def test_simple_context_str_no_emb() -> None:
-    expected = [{"a_namespace": "test"}]
-    assert base.embed("test", MockEncoder(), "a_namespace") == expected
+    expected = {"a_namespace": {"raw": "test"}}
+
+    featurized = base.embed("test", MockEncoder(), "a_namespace")
+    assert featurized.sparse == expected
+    assert featurized.dense == {}
 
 
 def test_simple_context_str_w_emb() -> None:
     str1 = "test"
-    encoded_str1 = base._stringify_embedding(list(encoded_keyword + str1))
-    expected = [{"a_namespace": encoded_str1}]
-    assert base.embed(base.Embed(str1), MockEncoder(), "a_namespace") == expected
-    expected_embed_and_keep = [{"a_namespace": str1 + " " + encoded_str1}]
-    assert (
-        base.embed(base.EmbedAndKeep(str1), MockEncoder(), "a_namespace")
-        == expected_embed_and_keep
-    )
+    expected_dense = {"a_namespace": [4.0, 0.0]}
+    expected_sparse = {"a_namespace": {"raw": str1}}
+
+    featurized = base.embed(base.Embed(str1), MockEncoder(), "a_namespace")
+    assert featurized.dense == expected_dense
+    assert featurized.sparse == {}
+
+    featurized = base.embed(base.EmbedAndKeep(str1), MockEncoder(), "a_namespace")
+    assert featurized.sparse == expected_sparse
+    assert featurized.dense == expected_dense
 
 
 def test_simple_context_str_w_nested_emb() -> None:
     # nested embeddings, innermost wins
     str1 = "test"
-    encoded_str1 = base._stringify_embedding(list(encoded_keyword + str1))
-    expected = [{"a_namespace": encoded_str1}]
-    assert (
-        base.embed(base.EmbedAndKeep(base.Embed(str1)), MockEncoder(), "a_namespace")
-        == expected
-    )
+    expected_dense = {"a_namespace": [4.0, 0.0]}
+    expected_sparse = {"a_namespace": {"raw": str1}}
 
-    expected2 = [{"a_namespace": str1 + " " + encoded_str1}]
-    assert (
-        base.embed(base.Embed(base.EmbedAndKeep(str1)), MockEncoder(), "a_namespace")
-        == expected2
-    )
+    featurized = base.embed(base.EmbedAndKeep(base.Embed(str1)), MockEncoder(), "a_namespace")
+    assert featurized.dense == expected_dense
+    assert featurized.sparse == {}
+
+    featurized = base.embed(base.Embed(base.EmbedAndKeep(str1)), MockEncoder(), "a_namespace")
+    assert featurized.sparse == expected_sparse
+    assert featurized.dense == expected_dense
 
 
 def test_context_w_namespace_no_emb() -> None:
-    expected = [{"test_namespace": "test"}]
-    assert base.embed({"test_namespace": "test"}, MockEncoder()) == expected
-
+    expected_sparse = {"test_namespace": {"raw": "test"}}
+    featurized = base.embed({"test_namespace": "test"}, MockEncoder())
+    assert featurized.sparse == expected_sparse
+    assert featurized.dense == {}
 
 def test_context_w_namespace_w_emb() -> None:
     str1 = "test"
-    encoded_str1 = base._stringify_embedding(list(encoded_keyword + str1))
-    expected = [{"test_namespace": encoded_str1}]
-    assert base.embed({"test_namespace": base.Embed(str1)}, MockEncoder()) == expected
-    expected_embed_and_keep = [{"test_namespace": str1 + " " + encoded_str1}]
-    assert (
-        base.embed({"test_namespace": base.EmbedAndKeep(str1)}, MockEncoder())
-        == expected_embed_and_keep
-    )
+    expected_sparse = {"test_namespace": {"raw": str1}}
+    expected_dense = {"test_namespace": [4.0, 0.0]}
+
+    featurized = base.embed({"test_namespace": base.Embed(str1)}, MockEncoder())
+    assert featurized.sparse == {}
+    assert featurized.dense == expected_dense
+
+    featurized = base.embed({"test_namespace": base.EmbedAndKeep(str1)}, MockEncoder())
+    assert featurized.sparse == expected_sparse
+    assert featurized.dense == expected_dense
 
 
 def test_context_w_namespace_w_emb2() -> None:
     str1 = "test"
-    encoded_str1 = base._stringify_embedding(list(encoded_keyword + str1))
-    expected = [{"test_namespace": encoded_str1}]
-    assert base.embed(base.Embed({"test_namespace": str1}), MockEncoder()) == expected
-    expected_embed_and_keep = [{"test_namespace": str1 + " " + encoded_str1}]
-    assert (
-        base.embed(base.EmbedAndKeep({"test_namespace": str1}), MockEncoder())
-        == expected_embed_and_keep
-    )
+    expected_sparse = {"test_namespace": {"raw": str1}}
+    expected_dense = {"test_namespace": [4.0, 0.0]}
+    
+    featurized = base.embed(base.Embed({"test_namespace": str1}), MockEncoder())
+    assert featurized.sparse == {}
+    assert featurized.dense == expected_dense
+
+    featurized = base.embed(base.EmbedAndKeep({"test_namespace": str1}), MockEncoder())
+    assert featurized.sparse == expected_sparse
+    assert featurized.dense == expected_dense
 
 
 def test_context_w_namespace_w_some_emb() -> None:
-    str1 = "test1"
-    str2 = "test2"
-    encoded_str2 = base._stringify_embedding(list(encoded_keyword + str2))
-    expected = [{"test_namespace": str1, "test_namespace2": encoded_str2}]
-    assert (
-        base.embed(
+    str1 = "test"
+    str2 = "test_"
+    expected_sparse = {"test_namespace": {"raw": str1}}
+    expected_dense = {"test_namespace2": [5.0, 0.0]}
+    featurized = base.embed(
             {"test_namespace": str1, "test_namespace2": base.Embed(str2)}, MockEncoder()
         )
-        == expected
-    )
-    expected_embed_and_keep = [
-        {"test_namespace": str1, "test_namespace2": str2 + " " + encoded_str2}
-    ]
-    assert (
-        base.embed(
+    assert featurized.sparse == expected_sparse
+    assert featurized.dense == expected_dense
+
+    expected_sparse = {"test_namespace": {"raw": str1}, "test_namespace2": {"raw": str2}}
+    featurized = base.embed(
             {"test_namespace": str1, "test_namespace2": base.EmbedAndKeep(str2)},
             MockEncoder(),
         )
-        == expected_embed_and_keep
-    )
+    assert featurized.sparse == expected_sparse
+    assert featurized.dense == expected_dense
 
 
 def test_simple_action_strlist_no_emb() -> None:
     str1 = "test1"
     str2 = "test2"
     str3 = "test3"
-    expected = [{"a_namespace": str1}, {"a_namespace": str2}, {"a_namespace": str3}]
+    expected_sparse = [
+        {"a_namespace": {"raw": str1}},
+        {"a_namespace": {"raw": str2}},
+        {"a_namespace": {"raw": str3}}]
     to_embed: List[Union[str, base._Embed]] = [str1, str2, str3]
-    assert base.embed(to_embed, MockEncoder(), "a_namespace") == expected
+    featurized = base.embed(to_embed, MockEncoder(), "a_namespace")
+
+    for i in range(len(featurized)):
+        assert featurized[i].sparse == expected_sparse[i]
+        assert featurized[i].dense == {}
 
 
 def test_simple_action_strlist_w_emb() -> None:
-    str1 = "test1"
-    str2 = "test2"
-    str3 = "test3"
-    encoded_str1 = base._stringify_embedding(list(encoded_keyword + str1))
-    encoded_str2 = base._stringify_embedding(list(encoded_keyword + str2))
-    encoded_str3 = base._stringify_embedding(list(encoded_keyword + str3))
-    expected = [
-        {"a_namespace": encoded_str1},
-        {"a_namespace": encoded_str2},
-        {"a_namespace": encoded_str3},
-    ]
-    assert (
-        base.embed(base.Embed([str1, str2, str3]), MockEncoder(), "a_namespace")
-        == expected
-    )
-    expected_embed_and_keep = [
-        {"a_namespace": str1 + " " + encoded_str1},
-        {"a_namespace": str2 + " " + encoded_str2},
-        {"a_namespace": str3 + " " + encoded_str3},
-    ]
-    assert (
-        base.embed(base.EmbedAndKeep([str1, str2, str3]), MockEncoder(), "a_namespace")
-        == expected_embed_and_keep
-    )
+    str1 = "test"
+    str2 = "test_"
+    str3 = "test__"
+
+    expected_sparse = [
+        {"a_namespace": {"raw": str1}},
+        {"a_namespace": {"raw": str2}},
+        {"a_namespace": {"raw": str3}}]
+    expected_dense = [
+        {"a_namespace": [4.0, 0.0]},
+        {"a_namespace": [5.0, 0.0]},
+        {"a_namespace": [6.0, 0.0]}]
+    
+    featurized = base.embed(base.Embed([str1, str2, str3]), MockEncoder(), "a_namespace")
+    for i in range(len(featurized)):
+        assert featurized[i].sparse == {}
+        assert featurized[i].dense == expected_dense[i]
+
+    featurized = base.embed(base.EmbedAndKeep([str1, str2, str3]), MockEncoder(), "a_namespace")
+    for i in range(len(featurized)):
+        assert featurized[i].sparse == expected_sparse[i]
+        assert featurized[i].dense == expected_dense[i]
 
 
 def test_simple_action_strlist_w_some_emb() -> None:
-    str1 = "test1"
-    str2 = "test2"
-    str3 = "test3"
-    encoded_str2 = base._stringify_embedding(list(encoded_keyword + str2))
-    encoded_str3 = base._stringify_embedding(list(encoded_keyword + str3))
-    expected = [
-        {"a_namespace": str1},
-        {"a_namespace": encoded_str2},
-        {"a_namespace": encoded_str3},
-    ]
-    assert (
-        base.embed(
-            [str1, base.Embed(str2), base.Embed(str3)], MockEncoder(), "a_namespace"
-        )
-        == expected
-    )
-    expected_embed_and_keep = [
-        {"a_namespace": str1},
-        {"a_namespace": str2 + " " + encoded_str2},
-        {"a_namespace": str3 + " " + encoded_str3},
-    ]
-    assert (
-        base.embed(
-            [str1, base.EmbedAndKeep(str2), base.EmbedAndKeep(str3)],
-            MockEncoder(),
-            "a_namespace",
-        )
-        == expected_embed_and_keep
-    )
+    str1 = "test"
+    str2 = "test_"
+    str3 = "test__"
+
+    expected_sparse = [
+        {"a_namespace": {"raw": str1}},
+        {},
+        {}]
+    expected_dense = [
+        {},
+        {"a_namespace": [5.0, 0.0]},
+        {"a_namespace": [6.0, 0.0]}]
+    featurized = base.embed([str1, base.Embed(str2), base.Embed(str3)], MockEncoder(), "a_namespace")
+    for i in range(len(featurized)):
+        assert featurized[i].sparse == expected_sparse[i]
+        assert featurized[i].dense == expected_dense[i]
+
+    featurized = base.embed([str1, base.EmbedAndKeep(str2), base.EmbedAndKeep(str3)], MockEncoder(), "a_namespace")
+    expected_sparse = [
+        {"a_namespace": {"raw": str1}},
+        {"a_namespace": {"raw": str2}},
+        {"a_namespace": {"raw": str3}}]
+    for i in range(len(featurized)):
+        assert featurized[i].sparse == expected_sparse[i]
+        assert featurized[i].dense == expected_dense[i]
 
 
 def test_action_w_namespace_no_emb() -> None:
     str1 = "test1"
     str2 = "test2"
     str3 = "test3"
-    expected = [
-        {"test_namespace": str1},
-        {"test_namespace": str2},
-        {"test_namespace": str3},
+    expected_sparse = [
+        {"test_namespace": {"raw": str1}},
+        {"test_namespace": {"raw": str2}},
+        {"test_namespace": {"raw": str3}},
     ]
-    assert (
-        base.embed(
+
+    featurized = base.embed(
             [
                 {"test_namespace": str1},
                 {"test_namespace": str2},
@@ -180,24 +184,26 @@ def test_action_w_namespace_no_emb() -> None:
             ],
             MockEncoder(),
         )
-        == expected
-    )
+    for i in range(len(featurized)):
+        assert featurized[i].sparse == expected_sparse[i]
+        assert featurized[i].dense == {}
 
 
 def test_action_w_namespace_w_emb() -> None:
-    str1 = "test1"
-    str2 = "test2"
-    str3 = "test3"
-    encoded_str1 = base._stringify_embedding(list(encoded_keyword + str1))
-    encoded_str2 = base._stringify_embedding(list(encoded_keyword + str2))
-    encoded_str3 = base._stringify_embedding(list(encoded_keyword + str3))
-    expected = [
-        {"test_namespace": encoded_str1},
-        {"test_namespace": encoded_str2},
-        {"test_namespace": encoded_str3},
+    str1 = "test"
+    str2 = "test_"
+    str3 = "test__"
+    expected_sparse = [
+        {"test_namespace": {"raw": str1}},
+        {"test_namespace": {"raw": str2}},
+        {"test_namespace": {"raw": str3}},
     ]
-    assert (
-        base.embed(
+    expected_dense = [
+        {"test_namespace": [4.0, 0.0]},
+        {"test_namespace": [5.0, 0.0]},
+        {"test_namespace": [6.0, 0.0]}]
+
+    featurized = base.embed(
             [
                 {"test_namespace": base.Embed(str1)},
                 {"test_namespace": base.Embed(str2)},
@@ -205,15 +211,11 @@ def test_action_w_namespace_w_emb() -> None:
             ],
             MockEncoder(),
         )
-        == expected
-    )
-    expected_embed_and_keep = [
-        {"test_namespace": str1 + " " + encoded_str1},
-        {"test_namespace": str2 + " " + encoded_str2},
-        {"test_namespace": str3 + " " + encoded_str3},
-    ]
-    assert (
-        base.embed(
+    for i in range(len(featurized)):
+        assert featurized[i].sparse == {}
+        assert featurized[i].dense == expected_dense[i]
+
+    featurized = base.embed(
             [
                 {"test_namespace": base.EmbedAndKeep(str1)},
                 {"test_namespace": base.EmbedAndKeep(str2)},
@@ -221,42 +223,41 @@ def test_action_w_namespace_w_emb() -> None:
             ],
             MockEncoder(),
         )
-        == expected_embed_and_keep
-    )
+    for i in range(len(featurized)):
+        assert featurized[i].sparse == expected_sparse[i]
+        assert featurized[i].dense == expected_dense[i]
+
 
 
 def test_action_w_namespace_w_emb2() -> None:
-    str1 = "test1"
-    str2 = "test2"
-    str3 = "test3"
-    encoded_str1 = base._stringify_embedding(list(encoded_keyword + str1))
-    encoded_str2 = base._stringify_embedding(list(encoded_keyword + str2))
-    encoded_str3 = base._stringify_embedding(list(encoded_keyword + str3))
-    expected = [
-        {"test_namespace1": encoded_str1},
-        {"test_namespace2": encoded_str2},
-        {"test_namespace3": encoded_str3},
+    str1 = "test"
+    str2 = "test_"
+    str3 = "test__"
+    expected_sparse = [
+        {"test_namespace1": {"raw": str1}},
+        {"test_namespace2": {"raw": str2}},
+        {"test_namespace3": {"raw": str3}},
     ]
-    assert (
-        base.embed(
-            base.Embed(
-                [
-                    {"test_namespace1": str1},
-                    {"test_namespace2": str2},
-                    {"test_namespace3": str3},
-                ]
-            ),
-            MockEncoder(),
-        )
-        == expected
-    )
-    expected_embed_and_keep = [
-        {"test_namespace1": str1 + " " + encoded_str1},
-        {"test_namespace2": str2 + " " + encoded_str2},
-        {"test_namespace3": str3 + " " + encoded_str3},
-    ]
-    assert (
-        base.embed(
+    expected_dense = [
+        {"test_namespace1": [4.0, 0.0]},
+        {"test_namespace2": [5.0, 0.0]},
+        {"test_namespace3": [6.0, 0.0]}]
+    
+    featurized = base.embed(
+                base.Embed(
+                    [
+                        {"test_namespace1": str1},
+                        {"test_namespace2": str2},
+                        {"test_namespace3": str3},
+                    ]
+                ),
+                MockEncoder(),
+            )
+    for i in range(len(featurized)):
+        assert featurized[i].sparse == {}
+        assert featurized[i].dense == expected_dense[i]
+
+    featurized = base.embed(
             base.EmbedAndKeep(
                 [
                     {"test_namespace1": str1},
@@ -266,23 +267,26 @@ def test_action_w_namespace_w_emb2() -> None:
             ),
             MockEncoder(),
         )
-        == expected_embed_and_keep
-    )
+    for i in range(len(featurized)):
+        assert featurized[i].sparse == expected_sparse[i]
+        assert featurized[i].dense == expected_dense[i]
 
 
 def test_action_w_namespace_w_some_emb() -> None:
-    str1 = "test1"
-    str2 = "test2"
-    str3 = "test3"
-    encoded_str2 = base._stringify_embedding(list(encoded_keyword + str2))
-    encoded_str3 = base._stringify_embedding(list(encoded_keyword + str3))
-    expected = [
-        {"test_namespace": str1},
-        {"test_namespace": encoded_str2},
-        {"test_namespace": encoded_str3},
+    str1 = "test"
+    str2 = "test_"
+    str3 = "test__"
+    expected_sparse = [
+        {"test_namespace": {"raw": str1}},
+        {},
+        {},
     ]
-    assert (
-        base.embed(
+    expected_dense = [
+        {},
+        {"test_namespace": [5.0, 0.0]},
+        {"test_namespace": [6.0, 0.0]}]
+    
+    featurized = base.embed(
             [
                 {"test_namespace": str1},
                 {"test_namespace": base.Embed(str2)},
@@ -290,15 +294,16 @@ def test_action_w_namespace_w_some_emb() -> None:
             ],
             MockEncoder(),
         )
-        == expected
-    )
-    expected_embed_and_keep = [
-        {"test_namespace": str1},
-        {"test_namespace": str2 + " " + encoded_str2},
-        {"test_namespace": str3 + " " + encoded_str3},
+    for i in range(len(featurized)):
+        assert featurized[i].sparse == expected_sparse[i]
+        assert featurized[i].dense == expected_dense[i]
+    
+    expected_sparse = [
+        {"test_namespace": {"raw": str1}},
+        {"test_namespace": {"raw": str2}},
+        {"test_namespace": {"raw": str3}},
     ]
-    assert (
-        base.embed(
+    featurized = base.embed(
             [
                 {"test_namespace": str1},
                 {"test_namespace": base.EmbedAndKeep(str2)},
@@ -306,24 +311,26 @@ def test_action_w_namespace_w_some_emb() -> None:
             ],
             MockEncoder(),
         )
-        == expected_embed_and_keep
-    )
+    for i in range(len(featurized)):
+        assert featurized[i].sparse == expected_sparse[i]
+        assert featurized[i].dense == expected_dense[i]
 
 
 def test_action_w_namespace_w_emb_w_more_than_one_item_in_first_dict() -> None:
-    str1 = "test1"
-    str2 = "test2"
-    str3 = "test3"
-    encoded_str1 = base._stringify_embedding(list(encoded_keyword + str1))
-    encoded_str2 = base._stringify_embedding(list(encoded_keyword + str2))
-    encoded_str3 = base._stringify_embedding(list(encoded_keyword + str3))
-    expected = [
-        {"test_namespace": encoded_str1, "test_namespace2": str1},
-        {"test_namespace": encoded_str2, "test_namespace2": str2},
-        {"test_namespace": encoded_str3, "test_namespace2": str3},
+    str1 = "test"
+    str2 = "test_"
+    str3 = "test__"
+    expected_sparse = [
+        {"test_namespace2": {"raw": str1}},
+        {"test_namespace2": {"raw": str2}},
+        {"test_namespace2": {"raw": str3}},
     ]
-    assert (
-        base.embed(
+    expected_dense = [
+        {"test_namespace": [4.0, 0.0]},
+        {"test_namespace": [5.0, 0.0]},
+        {"test_namespace": [6.0, 0.0]}]
+    
+    featurized = base.embed(
             [
                 {"test_namespace": base.Embed(str1), "test_namespace2": str1},
                 {"test_namespace": base.Embed(str2), "test_namespace2": str2},
@@ -331,15 +338,16 @@ def test_action_w_namespace_w_emb_w_more_than_one_item_in_first_dict() -> None:
             ],
             MockEncoder(),
         )
-        == expected
-    )
-    expected_embed_and_keep = [
-        {"test_namespace": str1 + " " + encoded_str1, "test_namespace2": str1},
-        {"test_namespace": str2 + " " + encoded_str2, "test_namespace2": str2},
-        {"test_namespace": str3 + " " + encoded_str3, "test_namespace2": str3},
+    for i in range(len(featurized)):
+        assert featurized[i].sparse == expected_sparse[i]
+        assert featurized[i].dense == expected_dense[i]
+
+    expected_sparse = [
+        {"test_namespace": {"raw": str1}, "test_namespace2": {"raw": str1}},
+        {"test_namespace": {"raw": str2}, "test_namespace2": {"raw": str2}},
+        {"test_namespace": {"raw": str3}, "test_namespace2": {"raw": str3}},
     ]
-    assert (
-        base.embed(
+    featurized = base.embed(
             [
                 {"test_namespace": base.EmbedAndKeep(str1), "test_namespace2": str1},
                 {"test_namespace": base.EmbedAndKeep(str2), "test_namespace2": str2},
@@ -347,26 +355,32 @@ def test_action_w_namespace_w_emb_w_more_than_one_item_in_first_dict() -> None:
             ],
             MockEncoder(),
         )
-        == expected_embed_and_keep
-    )
+    for i in range(len(featurized)):
+        assert featurized[i].sparse == expected_sparse[i]
+        assert featurized[i].dense == expected_dense[i]
 
 
 def test_one_namespace_w_list_of_features_no_emb() -> None:
     str1 = "test1"
     str2 = "test2"
-    expected = [{"test_namespace": [str1, str2]}]
-    assert base.embed({"test_namespace": [str1, str2]}, MockEncoder()) == expected
+    expected_sparse = {
+        "test_namespace_0": {"raw": str1},
+        "test_namespace_1": {"raw": str2}}
+
+    featurized = base.embed({"test_namespace": [str1, str2]}, MockEncoder())
+    assert featurized.sparse == expected_sparse
+    assert featurized.dense == {}
 
 
 def test_one_namespace_w_list_of_features_w_some_emb() -> None:
-    str1 = "test1"
-    str2 = "test2"
-    encoded_str2 = base._stringify_embedding(list(encoded_keyword + str2))
-    expected = [{"test_namespace": [str1, encoded_str2]}]
-    assert (
-        base.embed({"test_namespace": [str1, base.Embed(str2)]}, MockEncoder())
-        == expected
-    )
+    str1 = "test"
+    str2 = "test_"
+    expected_sparse = {"test_namespace_0": {"raw": str1}}
+    expected_dense = {"test_namespace_1": [5.0, 0.0]}
+
+    featurized = base.embed({"test_namespace": [str1, base.Embed(str2)]}, MockEncoder())
+    assert featurized.sparse == expected_sparse
+    assert featurized.dense == expected_dense
 
 
 def test_nested_list_features_throws() -> None:

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -3,7 +3,7 @@ from typing import Any, List
 
 class MockEncoder:
     def encode(self, to_encode: str) -> str:
-        return "[encoded]" + to_encode
+        return [float(len(to_encode)), 0.0]
 
 
 class MockEncoderReturnsList:


### PR DESCRIPTION
PickBestFeaturizer is now returning Featurized objects which are collections of sparse (dictionaries) and dense (lists) features and all vw-specific formatting is happening inside the VwPolicy (so featurizer can be reused in byom).